### PR TITLE
Add codemap dry-run stats action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,45 +2,20 @@
 
 ## [Unreleased]
 
-### Breaking Changes
-
 ### Added
-
-### Changed
-
-### Fixed
-
-### Removed
+- **codemap**: Add stats summary modal in the options panel (Dry run stats) using codemap JSON stats output
 
 ## [0.2.1] - 2026-01-21
-
-### Breaking Changes
-
-### Added
 
 ### Changed
 - **codemap**: Add a parent view so the project directory can be selected by name (via `..`)
 
-### Fixed
-
-### Removed
-
 ## [0.2.0] - 2026-01-21
-
-### Breaking Changes
 
 ### Added
 - **codemap**: Added codemap extension
 
-### Changed
-
-### Fixed
-
-### Removed
-
 ## [0.1.0] - 2026-01-21
-
-### Breaking Changes
 
 ### Added
 - **skill-picker**: Hard fork of [pi-skill-palette](https://github.com/nicobailon/pi-skill-palette) (MIT), adapted for pi-extensions.
@@ -56,11 +31,6 @@
 
 ### Removed
 - **skill-picker**: Confirmation dialog countdown timer and progress dots.
-
-### Fixed
-
-### Removed
-
 
 ## [0.0.1] - 2026-01-10
 

--- a/codemap/README.md
+++ b/codemap/README.md
@@ -55,7 +55,7 @@ Directories are expanded to `dir/**`, and glob arguments are single-quoted to pr
 |-----|--------|
 | `↑` / `↓` | Navigate options |
 | `Space` | Toggle checkbox on/off |
-| `Enter` | Toggle checkbox, or edit input field |
+| `Enter` | Toggle checkbox, run action, or edit input field |
 | `0-9` | Type directly into input field |
 | `Backspace` | Delete character (when editing) |
 | `Tab` / `Escape` | Return to file browser |
@@ -68,6 +68,8 @@ Directories are expanded to `dir/**`, and glob arguments are single-quoted to pr
 | Token budget | Limit output size with `-b` flag | 15000 |
 | Share with agent | Use `!` (shared) or `!!` (not shared with LLM) | On |
 
+Show dry run stats: Display the codemap stats summary for the current selection.
+
 ## Features
 
 - **Directory navigation**: Browse into subdirectories, go back with Esc or backspace
@@ -78,6 +80,7 @@ Directories are expanded to `dir/**`, and glob arguments are single-quoted to pr
 - **Gitignore support**: Respects .gitignore in git repos (Tab → Options → toggle)
 - **CWD restricted**: Cannot navigate above the working directory
 - **Editor integration**: Populates input with `!codemap ...` or `!!codemap ...`
+- **Stats summary**: Use Tab → Show dry run stats to view codemap stats for the current selection
 
 ## Search Modes
 


### PR DESCRIPTION
## Summary
- add a dry-run stats action in the codemap options panel with a generating indicator
- keep the stats modal using codemap JSON stats output
- clean empty changelog sections

## Testing
- Not run (not requested)