### PR TITLE
Add apply-patch-tool extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 - **assistant**: Add Assistant list/notes picker with metadata/content injection via `/assistant`
+- **apply-patch-tool**: Add Codex-style `apply_patch` tool extension with prompt guidance injection
 - **toolwatch**: Local rules evaluation mode
   - New `common/` module with shared types and rules engine
   - Extension now supports `rules.mode: "local"` for local policy enforcement without collector
@@ -21,6 +22,7 @@
 - **assistant**: Insert selections into the editor on confirm (codemap-style Enter behavior)
 - **assistant**: Include list item custom fields in injected metadata/content blocks
 - **assistant**: Format list item notes with User/Agent headings and expand custom fields into frontmatter keys
+- **apply-patch-tool**: Append unified diffs to tool output
 - **toolwatch**: Refactored extension and collector to use shared `common` module
   - Types, rules engine, and plugin loader extracted to `@pi-extensions/toolwatch-common`
   - Extension restructured into `src/` subdirectory with config, evaluator, audit modules

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Reload pi after installing.
 | Extension | Description |
 |-----------|-------------|
 | [codemap](codemap/) | File browser for selecting files/directories to pass to `codemap` via `/codemap`. |
+| [apply-patch-tool](apply-patch-tool/) | Codex-style `apply_patch` tool with prompt guidance injection. |
 | [assistant](assistant/) | Browse Assistant lists and notes with fuzzy search and inject selections via `/assistant`. |
 | [skill-picker](skill-picker/) | Command palette for selecting and queueing skills explicitly via `/skill` command. Hard fork of [pi-skill-palette](https://github.com/nicobailon/pi-skill-palette). |
 | [toolwatch](toolwatch/) | Tool call auditing and approval system. Log all tool calls to SQLite, block dangerous commands, require manual approval for sensitive operations. |

--- a/apply-patch-tool/README.md
+++ b/apply-patch-tool/README.md
@@ -1,0 +1,30 @@
+# apply-patch-tool
+
+Codex-style `apply_patch` tool for pi, plus prompt guidance injection.
+
+## Installation
+
+Copy the extension into your pi extensions directory:
+
+```bash
+cp -R /path/to/pi-extensions/apply-patch-tool ~/.pi/agent/extensions/apply-patch-tool
+```
+
+Restart pi (or reload extensions).
+
+## What it does
+
+- Registers an `apply_patch` tool that accepts Codex patch text.
+- Injects `apply_patch_prompt.md` once per session as a hidden custom message.
+- Applies patches with Codex-compatible parsing and output summaries.
+- Appends unified diffs to tool output (Codex-style).
+
+## Prompt file
+
+The extension loads `apply_patch_prompt.md` from the extension directory and injects it once at session start (as a persistent custom message). It is not appended to the system prompt on every turn.
+
+## Testing
+
+```bash
+cd apply-patch-tool && npm test
+```

--- a/apply-patch-tool/apply_patch_prompt.md
+++ b/apply-patch-tool/apply_patch_prompt.md
@@ -1,0 +1,75 @@
+## `apply_patch`
+
+Use the `apply_patch` shell command to edit files.
+Your patch language is a stripped‑down, file‑oriented diff format designed to be easy to parse and safe to apply. You can think of it as a high‑level envelope:
+
+*** Begin Patch
+[ one or more file sections ]
+*** End Patch
+
+Within that envelope, you get a sequence of file operations.
+You MUST include a header to specify the action you are taking.
+Each operation starts with one of three headers:
+
+*** Add File: <path> - create a new file. Every following line is a + line (the initial contents).
+*** Delete File: <path> - remove an existing file. Nothing follows.
+*** Update File: <path> - patch an existing file in place (optionally with a rename).
+
+May be immediately followed by *** Move to: <new path> if you want to rename the file.
+Then one or more “hunks”, each introduced by @@ (optionally followed by a hunk header).
+Within a hunk each line starts with:
+
+For instructions on [context_before] and [context_after]:
+- By default, show 3 lines of code immediately above and 3 lines immediately below each change. If a change is within 3 lines of a previous change, do NOT duplicate the first change’s [context_after] lines in the second change’s [context_before] lines.
+- If 3 lines of context is insufficient to uniquely identify the snippet of code within the file, use the @@ operator to indicate the class or function to which the snippet belongs. For instance, we might have:
+@@ class BaseClass
+[3 lines of pre-context]
+- [old_code]
++ [new_code]
+[3 lines of post-context]
+
+- If a code block is repeated so many times in a class or function such that even a single `@@` statement and 3 lines of context cannot uniquely identify the snippet of code, you can use multiple `@@` statements to jump to the right context. For instance:
+
+@@ class BaseClass
+@@ 	 def method():
+[3 lines of pre-context]
+- [old_code]
++ [new_code]
+[3 lines of post-context]
+
+The full grammar definition is below:
+Patch := Begin { FileOp } End
+Begin := "*** Begin Patch" NEWLINE
+End := "*** End Patch" NEWLINE
+FileOp := AddFile | DeleteFile | UpdateFile
+AddFile := "*** Add File: " path NEWLINE { "+" line NEWLINE }
+DeleteFile := "*** Delete File: " path NEWLINE
+UpdateFile := "*** Update File: " path NEWLINE [ MoveTo ] { Hunk }
+MoveTo := "*** Move to: " newPath NEWLINE
+Hunk := "@@" [ header ] NEWLINE { HunkLine } [ "*** End of File" NEWLINE ]
+HunkLine := (" " | "-" | "+") text NEWLINE
+
+A full patch can combine several operations:
+
+*** Begin Patch
+*** Add File: hello.txt
++Hello world
+*** Update File: src/app.py
+*** Move to: src/main.py
+@@ def greet():
+-print("Hi")
++print("Hello, world!")
+*** Delete File: obsolete.txt
+*** End Patch
+
+It is important to remember:
+
+- You must include a header with your intended action (Add/Delete/Update)
+- You must prefix new lines with `+` even when creating a new file
+- File references can only be relative, NEVER ABSOLUTE.
+
+You can invoke apply_patch like:
+
+```
+shell {"command":["apply_patch","*** Begin Patch\n*** Add File: hello.txt\n+Hello, world!\n*** End Patch\n"]}
+```

--- a/apply-patch-tool/index.test.ts
+++ b/apply-patch-tool/index.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { buildToolOutput } from "./tool-output.ts";
+import { applyPatch } from "./patch.ts";
+
+function withTempDir(fn: (dir: string) => void): void {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "apply-patch-tool-"));
+  try {
+    fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("buildToolOutput appends unified diff for single file", () => {
+  withTempDir((dir) => {
+    const targetPath = path.join(dir, "test.txt");
+    const initial = [
+      "line1",
+      "line2",
+      "line3",
+      "line4",
+      "line5",
+      "line6",
+      "line7",
+      "line8",
+      "line9",
+      "line10",
+    ].join("\n");
+    fs.writeFileSync(targetPath, `${initial}\n`);
+
+    const patch =
+      "*** Begin Patch\n*** Update File: test.txt\n@@\n-line3\n+line3 updated\n*** End Patch";
+    const result = applyPatch(patch, dir);
+
+    const output = buildToolOutput(result);
+    const expectedSummary = "Success. Updated the following files:\nM test.txt\n";
+    assert.equal(
+      output,
+      `${expectedSummary}\n` +
+        "diff --git a/test.txt b/test.txt\n" +
+        "--- a/test.txt\n" +
+        "+++ b/test.txt\n" +
+        "@@ -2,3 +2,3 @@\n" +
+        " line2\n" +
+        "-line3\n" +
+        "+line3 updated\n" +
+        " line4\n",
+    );
+  });
+});
+
+test("buildToolOutput appends unified diff for multi-file changes", () => {
+  withTempDir((dir) => {
+    fs.writeFileSync(path.join(dir, "a.txt"), "alpha\n");
+    fs.writeFileSync(path.join(dir, "b.txt"), "bravo\n");
+
+    const patch =
+      "*** Begin Patch\n*** Update File: a.txt\n@@\n-alpha\n+alpha2\n*** Update File: b.txt\n@@\n-bravo\n+bravo2\n*** End Patch";
+    const result = applyPatch(patch, dir);
+    assert.equal(result.summary, "Success. Updated the following files:\nM a.txt\nM b.txt\n");
+    assert.equal(
+      buildToolOutput(result),
+      "Success. Updated the following files:\nM a.txt\nM b.txt\n\n" +
+        "diff --git a/a.txt b/a.txt\n" +
+        "--- a/a.txt\n" +
+        "+++ b/a.txt\n" +
+        "@@ -1,1 +1,1 @@\n" +
+        "-alpha\n" +
+        "+alpha2\n" +
+        "\n" +
+        "diff --git a/b.txt b/b.txt\n" +
+        "--- a/b.txt\n" +
+        "+++ b/b.txt\n" +
+        "@@ -1,1 +1,1 @@\n" +
+        "-bravo\n" +
+        "+bravo2\n",
+    );
+  });
+});

--- a/apply-patch-tool/index.ts
+++ b/apply-patch-tool/index.ts
@@ -1,0 +1,67 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { applyPatch } from "./patch.js";
+import { buildToolOutput } from "./tool-output.js";
+
+const PROMPT_MESSAGE_TYPE = "apply-patch-tool-instructions";
+const PROMPT_FILENAME = "apply_patch_prompt.md";
+
+function getExtensionDir(): string {
+  return path.dirname(fileURLToPath(import.meta.url));
+}
+
+function loadPromptText(): string {
+  const promptPath = path.join(getExtensionDir(), PROMPT_FILENAME);
+  return fs.readFileSync(promptPath, "utf-8");
+}
+
+function isCustomMessageEntry(entry: unknown): entry is { type: "custom_message"; customType: string } {
+  if (!entry || typeof entry !== "object") return false;
+  const record = entry as Record<string, unknown>;
+  return record.type === "custom_message" && typeof record.customType === "string";
+}
+
+export default function (pi: ExtensionAPI) {
+  const promptText = loadPromptText();
+  let shouldInjectPrompt = true;
+
+  pi.on("session_start", (_event, ctx) => {
+    const entries = ctx.sessionManager.getEntries();
+    shouldInjectPrompt = !entries.some(
+      (entry) => isCustomMessageEntry(entry) && entry.customType === PROMPT_MESSAGE_TYPE,
+    );
+  });
+
+  pi.on("before_agent_start", () => {
+    if (!shouldInjectPrompt) return undefined;
+    shouldInjectPrompt = false;
+    return {
+      message: {
+        customType: PROMPT_MESSAGE_TYPE,
+        content: promptText,
+        display: false,
+      },
+    };
+  });
+
+  pi.registerTool({
+    name: "apply_patch",
+    label: "Apply Patch",
+    description: "Apply a patch to files using the Codex apply_patch format.",
+    parameters: Type.Object({
+      input: Type.String({
+        description: "Patch text starting with *** Begin Patch and ending with *** End Patch.",
+      }),
+    }),
+    async execute(_toolCallId, params, _onUpdate, ctx) {
+      const result = applyPatch(params.input, ctx.cwd);
+      return {
+        content: [{ type: "text", text: buildToolOutput(result) }],
+        details: result.details,
+      };
+    },
+  });
+}

--- a/apply-patch-tool/package-lock.json
+++ b/apply-patch-tool/package-lock.json
@@ -1,0 +1,557 @@
+{
+  "name": "apply-patch-tool",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "apply-patch-tool",
+      "version": "0.1.0",
+      "devDependencies": {
+        "tsx": "^4.19.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.2",
+        "@esbuild/android-arm": "0.27.2",
+        "@esbuild/android-arm64": "0.27.2",
+        "@esbuild/android-x64": "0.27.2",
+        "@esbuild/darwin-arm64": "0.27.2",
+        "@esbuild/darwin-x64": "0.27.2",
+        "@esbuild/freebsd-arm64": "0.27.2",
+        "@esbuild/freebsd-x64": "0.27.2",
+        "@esbuild/linux-arm": "0.27.2",
+        "@esbuild/linux-arm64": "0.27.2",
+        "@esbuild/linux-ia32": "0.27.2",
+        "@esbuild/linux-loong64": "0.27.2",
+        "@esbuild/linux-mips64el": "0.27.2",
+        "@esbuild/linux-ppc64": "0.27.2",
+        "@esbuild/linux-riscv64": "0.27.2",
+        "@esbuild/linux-s390x": "0.27.2",
+        "@esbuild/linux-x64": "0.27.2",
+        "@esbuild/netbsd-arm64": "0.27.2",
+        "@esbuild/netbsd-x64": "0.27.2",
+        "@esbuild/openbsd-arm64": "0.27.2",
+        "@esbuild/openbsd-x64": "0.27.2",
+        "@esbuild/openharmony-arm64": "0.27.2",
+        "@esbuild/sunos-x64": "0.27.2",
+        "@esbuild/win32-arm64": "0.27.2",
+        "@esbuild/win32-ia32": "0.27.2",
+        "@esbuild/win32-x64": "0.27.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    }
+  }
+}

--- a/apply-patch-tool/package.json
+++ b/apply-patch-tool/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "apply-patch-tool",
+  "version": "0.1.0",
+  "description": "Codex-style apply_patch tool extension for pi",
+  "main": "index.ts",
+  "type": "module",
+  "scripts": {
+    "test": "node --test --import tsx"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2"
+  }
+}

--- a/apply-patch-tool/patch.test.ts
+++ b/apply-patch-tool/patch.test.ts
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { applyPatch } from "./patch.ts";
+
+function withTempDir(fn: (dir: string) => void): void {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "apply-patch-tool-"));
+  try {
+    fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("applyPatch applies multiple operations", () => {
+  withTempDir((dir) => {
+    const modifyPath = path.join(dir, "modify.txt");
+    const deletePath = path.join(dir, "delete.txt");
+    fs.writeFileSync(modifyPath, "line1\nline2\n");
+    fs.writeFileSync(deletePath, "obsolete\n");
+
+    const patch =
+      "*** Begin Patch\n*** Add File: nested/new.txt\n+created\n*** Delete File: delete.txt\n*** Update File: modify.txt\n@@\n-line2\n+changed\n*** End Patch";
+
+    const result = applyPatch(patch, dir);
+    assert.equal(
+      result.summary,
+      "Success. Updated the following files:\nA nested/new.txt\nM modify.txt\nD delete.txt\n",
+    );
+    assert.equal(fs.readFileSync(path.join(dir, "nested/new.txt"), "utf-8"), "created\n");
+    assert.equal(fs.readFileSync(modifyPath, "utf-8"), "line1\nchanged\n");
+    assert.equal(fs.existsSync(deletePath), false);
+  });
+});
+
+test("applyPatch applies multiple chunks", () => {
+  withTempDir((dir) => {
+    const targetPath = path.join(dir, "multi.txt");
+    fs.writeFileSync(targetPath, "line1\nline2\nline3\nline4\n");
+
+    const patch =
+      "*** Begin Patch\n*** Update File: multi.txt\n@@\n-line2\n+changed2\n@@\n-line4\n+changed4\n*** End Patch";
+
+    const result = applyPatch(patch, dir);
+    assert.equal(result.summary, "Success. Updated the following files:\nM multi.txt\n");
+    assert.equal(fs.readFileSync(targetPath, "utf-8"), "line1\nchanged2\nline3\nchanged4\n");
+  });
+});
+
+test("applyPatch moves files to new directories", () => {
+  withTempDir((dir) => {
+    const originalPath = path.join(dir, "old/name.txt");
+    const newPath = path.join(dir, "renamed/dir/name.txt");
+    fs.mkdirSync(path.dirname(originalPath), { recursive: true });
+    fs.writeFileSync(originalPath, "old content\n");
+
+    const patch =
+      "*** Begin Patch\n*** Update File: old/name.txt\n*** Move to: renamed/dir/name.txt\n@@\n-old content\n+new content\n*** End Patch";
+
+    const result = applyPatch(patch, dir);
+    assert.equal(result.summary, "Success. Updated the following files:\nM renamed/dir/name.txt\n");
+    assert.equal(fs.existsSync(originalPath), false);
+    assert.equal(fs.readFileSync(newPath, "utf-8"), "new content\n");
+  });
+});
+
+test("applyPatch rejects empty patch", () => {
+  withTempDir((dir) => {
+    assert.throws(
+      () => applyPatch("*** Begin Patch\n*** End Patch", dir),
+      new Error("No files were modified.\n"),
+    );
+  });
+});
+
+test("applyPatch reports missing context", () => {
+  withTempDir((dir) => {
+    const targetPath = path.join(dir, "modify.txt");
+    fs.writeFileSync(targetPath, "line1\nline2\n");
+
+    const patch =
+      "*** Begin Patch\n*** Update File: modify.txt\n@@\n-missing\n+changed\n*** End Patch";
+
+    assert.throws(
+      () => applyPatch(patch, dir),
+      new Error("Failed to find expected lines in modify.txt:\nmissing\n"),
+    );
+    assert.equal(fs.readFileSync(targetPath, "utf-8"), "line1\nline2\n");
+  });
+});
+
+test("applyPatch rejects missing file delete", () => {
+  withTempDir((dir) => {
+    const patch = "*** Begin Patch\n*** Delete File: missing.txt\n*** End Patch";
+    assert.throws(() => applyPatch(patch, dir), new Error("Failed to delete file missing.txt\n"));
+  });
+});
+
+test("applyPatch rejects empty update hunk", () => {
+  withTempDir((dir) => {
+    const patch = "*** Begin Patch\n*** Update File: foo.txt\n*** End Patch";
+    assert.throws(
+      () => applyPatch(patch, dir),
+      new Error("Invalid patch hunk on line 2: Update file hunk for path 'foo.txt' is empty\n"),
+    );
+  });
+});
+
+test("applyPatch requires existing file for update", () => {
+  withTempDir((dir) => {
+    const patch = "*** Begin Patch\n*** Update File: missing.txt\n@@\n-old\n+new\n*** End Patch";
+    assert.throws(
+      () => applyPatch(patch, dir),
+      new Error(
+        "Failed to read file to update missing.txt: No such file or directory (os error 2)\n",
+      ),
+    );
+  });
+});
+
+test("applyPatch move overwrites existing destination", () => {
+  withTempDir((dir) => {
+    const originalPath = path.join(dir, "old/name.txt");
+    const destination = path.join(dir, "renamed/dir/name.txt");
+    fs.mkdirSync(path.dirname(originalPath), { recursive: true });
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.writeFileSync(originalPath, "from\n");
+    fs.writeFileSync(destination, "existing\n");
+
+    const patch =
+      "*** Begin Patch\n*** Update File: old/name.txt\n*** Move to: renamed/dir/name.txt\n@@\n-from\n+new\n*** End Patch";
+
+    const result = applyPatch(patch, dir);
+    assert.equal(result.summary, "Success. Updated the following files:\nM renamed/dir/name.txt\n");
+    assert.equal(fs.existsSync(originalPath), false);
+    assert.equal(fs.readFileSync(destination, "utf-8"), "new\n");
+  });
+});
+
+test("applyPatch add overwrites existing file", () => {
+  withTempDir((dir) => {
+    const filePath = path.join(dir, "duplicate.txt");
+    fs.writeFileSync(filePath, "old content\n");
+
+    const patch = "*** Begin Patch\n*** Add File: duplicate.txt\n+new content\n*** End Patch";
+    const result = applyPatch(patch, dir);
+    assert.equal(result.summary, "Success. Updated the following files:\nA duplicate.txt\n");
+    assert.equal(fs.readFileSync(filePath, "utf-8"), "new content\n");
+  });
+});
+
+test("applyPatch delete directory fails", () => {
+  withTempDir((dir) => {
+    fs.mkdirSync(path.join(dir, "dir"));
+    const patch = "*** Begin Patch\n*** Delete File: dir\n*** End Patch";
+    assert.throws(() => applyPatch(patch, dir), new Error("Failed to delete file dir\n"));
+  });
+});
+
+test("applyPatch rejects invalid hunk header", () => {
+  withTempDir((dir) => {
+    const patch = "*** Begin Patch\n*** Frobnicate File: foo\n*** End Patch";
+    assert.throws(
+      () => applyPatch(patch, dir),
+      new Error(
+        "Invalid patch hunk on line 2: '*** Frobnicate File: foo' is not a valid hunk header. Valid hunk headers: '*** Add File: {path}', '*** Delete File: {path}', '*** Update File: {path}'\n",
+      ),
+    );
+  });
+});
+
+test("applyPatch updates file and appends trailing newline", () => {
+  withTempDir((dir) => {
+    const filePath = path.join(dir, "no_newline.txt");
+    fs.writeFileSync(filePath, "no newline at end");
+    const patch =
+      "*** Begin Patch\n*** Update File: no_newline.txt\n@@\n-no newline at end\n+first line\n+second line\n*** End Patch";
+
+    const result = applyPatch(patch, dir);
+    assert.equal(result.summary, "Success. Updated the following files:\nM no_newline.txt\n");
+    const contents = fs.readFileSync(filePath, "utf-8");
+    assert.ok(contents.endsWith("\n"));
+    assert.equal(contents, "first line\nsecond line\n");
+  });
+});
+
+test("applyPatch failure after partial success leaves changes", () => {
+  withTempDir((dir) => {
+    const patch =
+      "*** Begin Patch\n*** Add File: created.txt\n+hello\n*** Update File: missing.txt\n@@\n-old\n+new\n*** End Patch";
+
+    assert.throws(
+      () => applyPatch(patch, dir),
+      new Error(
+        "Failed to read file to update missing.txt: No such file or directory (os error 2)\n",
+      ),
+    );
+    assert.equal(fs.readFileSync(path.join(dir, "created.txt"), "utf-8"), "hello\n");
+  });
+});
+
+test("applyPatch rejects path traversal outside cwd", () => {
+  withTempDir((dir) => {
+    const outsidePath = path.join(dir, "..", "escape.txt");
+    const patch = "*** Begin Patch\n*** Add File: ../escape.txt\n+outside\n*** End Patch";
+
+    assert.throws(
+      () => applyPatch(patch, dir),
+      new Error("patch rejected: writing outside of the project; rejected by user approval settings\n"),
+    );
+    assert.equal(fs.existsSync(outsidePath), false);
+  });
+});

--- a/apply-patch-tool/patch.ts
+++ b/apply-patch-tool/patch.ts
@@ -1,0 +1,859 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const BEGIN_PATCH_MARKER = "*** Begin Patch";
+const END_PATCH_MARKER = "*** End Patch";
+const ADD_FILE_MARKER = "*** Add File: ";
+const DELETE_FILE_MARKER = "*** Delete File: ";
+const UPDATE_FILE_MARKER = "*** Update File: ";
+const MOVE_TO_MARKER = "*** Move to: ";
+const EOF_MARKER = "*** End of File";
+const CHANGE_CONTEXT_MARKER = "@@ ";
+const EMPTY_CHANGE_CONTEXT_MARKER = "@@";
+
+type ParseMode = "strict" | "lenient";
+
+class PatchParseError extends Error {
+  readonly kind: "invalid_patch" | "invalid_hunk";
+  readonly lineNumber?: number;
+
+  constructor(kind: "invalid_patch" | "invalid_hunk", message: string, lineNumber?: number) {
+    super(message);
+    this.kind = kind;
+    this.lineNumber = lineNumber;
+  }
+}
+
+interface ApplyPatchArgs {
+  hunks: Hunk[];
+  patch: string;
+}
+
+type Hunk = AddFileHunk | DeleteFileHunk | UpdateFileHunk;
+
+interface AddFileHunk {
+  kind: "add";
+  path: string;
+  contents: string;
+}
+
+interface DeleteFileHunk {
+  kind: "delete";
+  path: string;
+}
+
+interface UpdateFileHunk {
+  kind: "update";
+  path: string;
+  movePath?: string;
+  chunks: UpdateFileChunk[];
+}
+
+interface UpdateFileChunk {
+  changeContext?: string;
+  oldLines: string[];
+  newLines: string[];
+  isEndOfFile: boolean;
+}
+
+interface Replacement {
+  startIndex: number;
+  oldLen: number;
+  newLines: string[];
+}
+
+export interface ApplyPatchFileDetail {
+  path: string;
+  status: "added" | "modified" | "deleted";
+  moveFrom?: string;
+  moveTo?: string;
+  unifiedDiff: string;
+}
+
+export interface ApplyPatchDetails {
+  added: string[];
+  modified: string[];
+  deleted: string[];
+  files: ApplyPatchFileDetail[];
+}
+
+export interface ApplyPatchResult {
+  summary: string;
+  details: ApplyPatchDetails;
+}
+
+interface AffectedPaths {
+  added: string[];
+  modified: string[];
+  deleted: string[];
+}
+
+interface AppliedPatch {
+  originalContents: string;
+  newContents: string;
+  replacements: Replacement[];
+  originalLines: string[];
+  newLines: string[];
+}
+
+export function applyPatch(patchText: string, cwd: string): ApplyPatchResult {
+  let args: ApplyPatchArgs;
+  try {
+    args = parsePatch(patchText);
+  } catch (err) {
+    if (err instanceof PatchParseError) {
+      if (err.kind === "invalid_patch") {
+        throwError(`Invalid patch: ${err.message}`);
+      }
+      const lineNumber = err.lineNumber ?? 0;
+      throwError(`Invalid patch hunk on line ${lineNumber}: ${err.message}`);
+    }
+    throw err;
+  }
+  const { affected, details } = applyHunks(args.hunks, cwd);
+  return {
+    summary: formatSummary(affected),
+    details,
+  };
+}
+
+function parsePatch(patchText: string): ApplyPatchArgs {
+  const mode: ParseMode = "lenient";
+  return parsePatchText(patchText, mode);
+}
+
+function parsePatchText(patchText: string, mode: ParseMode): ApplyPatchArgs {
+  const lines = patchText.trim().split("\n");
+  let parsedLines = lines;
+  try {
+    checkPatchBoundariesStrict(parsedLines);
+  } catch (err) {
+    if (mode === "strict") {
+      throw err;
+    }
+    const error = err instanceof PatchParseError ? err : new PatchParseError("invalid_patch", String(err));
+    parsedLines = checkPatchBoundariesLenient(parsedLines, error);
+  }
+
+  const hunks: Hunk[] = [];
+  const lastLineIndex = parsedLines.length > 0 ? parsedLines.length - 1 : 0;
+  let remaining = parsedLines.slice(1, lastLineIndex);
+  let lineNumber = 2;
+  while (remaining.length > 0) {
+    const { hunk, consumed } = parseOneHunk(remaining, lineNumber);
+    hunks.push(hunk);
+    lineNumber += consumed;
+    remaining = remaining.slice(consumed);
+  }
+
+  return { hunks, patch: parsedLines.join("\n") };
+}
+
+function checkPatchBoundariesStrict(lines: string[]): void {
+  const firstLine = lines.length > 0 ? lines[0] : undefined;
+  const lastLine = lines.length > 0 ? lines[lines.length - 1] : undefined;
+  checkStartAndEndLinesStrict(firstLine, lastLine);
+}
+
+function checkStartAndEndLinesStrict(firstLine?: string, lastLine?: string): void {
+  const first = firstLine?.trim();
+  const last = lastLine?.trim();
+
+  if (first === BEGIN_PATCH_MARKER && last === END_PATCH_MARKER) {
+    return;
+  }
+
+  if (first !== BEGIN_PATCH_MARKER) {
+    throw new PatchParseError("invalid_patch", "The first line of the patch must be '*** Begin Patch'");
+  }
+
+  throw new PatchParseError("invalid_patch", "The last line of the patch must be '*** End Patch'");
+}
+
+function checkPatchBoundariesLenient(lines: string[], originalError: PatchParseError): string[] {
+  if (lines.length >= 4) {
+    const first = lines[0];
+    const last = lines[lines.length - 1];
+    if ((first === "<<EOF" || first === "<<'EOF'" || first === '<<"EOF"') && last.endsWith("EOF")) {
+      const innerLines = lines.slice(1, lines.length - 1);
+      checkPatchBoundariesStrict(innerLines);
+      return innerLines;
+    }
+  }
+
+  throw originalError;
+}
+
+function parseOneHunk(lines: string[], lineNumber: number): { hunk: Hunk; consumed: number } {
+  const firstLine = lines[0].trim();
+
+  if (firstLine.startsWith(ADD_FILE_MARKER)) {
+    const filePath = firstLine.slice(ADD_FILE_MARKER.length);
+    let contents = "";
+    let parsedLines = 1;
+    for (const addLine of lines.slice(1)) {
+      if (addLine.startsWith("+")) {
+        contents += `${addLine.slice(1)}\n`;
+        parsedLines += 1;
+      } else {
+        break;
+      }
+    }
+    return { hunk: { kind: "add", path: filePath, contents }, consumed: parsedLines };
+  }
+
+  if (firstLine.startsWith(DELETE_FILE_MARKER)) {
+    const filePath = firstLine.slice(DELETE_FILE_MARKER.length);
+    return { hunk: { kind: "delete", path: filePath }, consumed: 1 };
+  }
+
+  if (firstLine.startsWith(UPDATE_FILE_MARKER)) {
+    const filePath = firstLine.slice(UPDATE_FILE_MARKER.length);
+    let remaining = lines.slice(1);
+    let parsedLines = 1;
+
+    let movePath: string | undefined;
+    if (remaining[0]?.startsWith(MOVE_TO_MARKER)) {
+      movePath = remaining[0].slice(MOVE_TO_MARKER.length);
+      remaining = remaining.slice(1);
+      parsedLines += 1;
+    }
+
+    const chunks: UpdateFileChunk[] = [];
+    while (remaining.length > 0) {
+      if (remaining[0].trim() === "") {
+        remaining = remaining.slice(1);
+        parsedLines += 1;
+        continue;
+      }
+
+      if (remaining[0].startsWith("***")) {
+        break;
+      }
+
+      const chunk = parseUpdateFileChunk(remaining, lineNumber + parsedLines, chunks.length === 0);
+      chunks.push(chunk.chunk);
+      parsedLines += chunk.consumed;
+      remaining = remaining.slice(chunk.consumed);
+    }
+
+    if (chunks.length === 0) {
+      throw new PatchParseError(
+        "invalid_hunk",
+        `Update file hunk for path '${filePath}' is empty`,
+        lineNumber,
+      );
+    }
+
+    return {
+      hunk: {
+        kind: "update",
+        path: filePath,
+        movePath,
+        chunks,
+      },
+      consumed: parsedLines,
+    };
+  }
+
+  throw new PatchParseError(
+    "invalid_hunk",
+    `'${firstLine}' is not a valid hunk header. Valid hunk headers: '*** Add File: {path}', '*** Delete File: {path}', '*** Update File: {path}'`,
+    lineNumber,
+  );
+}
+
+function parseUpdateFileChunk(
+  lines: string[],
+  lineNumber: number,
+  allowMissingContext: boolean,
+): { chunk: UpdateFileChunk; consumed: number } {
+  if (lines.length === 0) {
+    throw new PatchParseError("invalid_hunk", "Update hunk does not contain any lines", lineNumber);
+  }
+
+  let changeContext: string | undefined;
+  let startIndex: number;
+
+  if (lines[0] === EMPTY_CHANGE_CONTEXT_MARKER) {
+    changeContext = undefined;
+    startIndex = 1;
+  } else if (lines[0].startsWith(CHANGE_CONTEXT_MARKER)) {
+    changeContext = lines[0].slice(CHANGE_CONTEXT_MARKER.length);
+    startIndex = 1;
+  } else {
+    if (!allowMissingContext) {
+      throw new PatchParseError(
+        "invalid_hunk",
+        `Expected update hunk to start with a @@ context marker, got: '${lines[0]}'`,
+        lineNumber,
+      );
+    }
+    changeContext = undefined;
+    startIndex = 0;
+  }
+
+  if (startIndex >= lines.length) {
+    throw new PatchParseError("invalid_hunk", "Update hunk does not contain any lines", lineNumber + 1);
+  }
+
+  const chunk: UpdateFileChunk = {
+    changeContext,
+    oldLines: [],
+    newLines: [],
+    isEndOfFile: false,
+  };
+
+  let parsedLines = 0;
+  for (const line of lines.slice(startIndex)) {
+    if (line === EOF_MARKER) {
+      if (parsedLines === 0) {
+        throw new PatchParseError("invalid_hunk", "Update hunk does not contain any lines", lineNumber + 1);
+      }
+      chunk.isEndOfFile = true;
+      parsedLines += 1;
+      break;
+    }
+
+    if (line.length === 0) {
+      chunk.oldLines.push("");
+      chunk.newLines.push("");
+      parsedLines += 1;
+      continue;
+    }
+
+    const prefix = line[0];
+    const content = line.slice(1);
+    if (prefix === " ") {
+      chunk.oldLines.push(content);
+      chunk.newLines.push(content);
+      parsedLines += 1;
+      continue;
+    }
+    if (prefix === "+") {
+      chunk.newLines.push(content);
+      parsedLines += 1;
+      continue;
+    }
+    if (prefix === "-") {
+      chunk.oldLines.push(content);
+      parsedLines += 1;
+      continue;
+    }
+
+    if (parsedLines === 0) {
+      throw new PatchParseError(
+        "invalid_hunk",
+        `Unexpected line found in update hunk: '${line}'. Every line should start with ' ' (context line), '+' (added line), or '-' (removed line)`,
+        lineNumber + 1,
+      );
+    }
+
+    break;
+  }
+
+  return { chunk, consumed: parsedLines + startIndex };
+}
+
+function applyHunks(hunks: Hunk[], cwd: string): { affected: AffectedPaths; details: ApplyPatchDetails } {
+  if (hunks.length === 0) {
+    throwError("No files were modified.");
+  }
+
+  const added: string[] = [];
+  const modified: string[] = [];
+  const deleted: string[] = [];
+  const files: ApplyPatchFileDetail[] = [];
+
+  for (const hunk of hunks) {
+    if (hunk.kind === "add") {
+      const displayPath = hunk.path;
+      const absPath = resolveFsPath(displayPath, cwd);
+      ensureParentDir(absPath, displayPath);
+      writeFileOrThrow(absPath, displayPath, hunk.contents);
+
+      added.push(displayPath);
+      files.push({
+        path: displayPath,
+        status: "added",
+        unifiedDiff: buildAddDiff(displayPath, hunk.contents),
+      });
+      continue;
+    }
+
+    if (hunk.kind === "delete") {
+      const displayPath = hunk.path;
+      const absPath = resolveFsPath(displayPath, cwd);
+      const existingContents = readFileOptional(absPath);
+      deleteFileOrThrow(absPath, displayPath);
+
+      deleted.push(displayPath);
+      files.push({
+        path: displayPath,
+        status: "deleted",
+        unifiedDiff: buildDeleteDiff(displayPath, existingContents),
+      });
+      continue;
+    }
+
+    const displayPath = hunk.path;
+    const absPath = resolveFsPath(displayPath, cwd);
+    const applied = deriveNewContentsFromChunks(absPath, displayPath, hunk.chunks);
+    const destDisplay = hunk.movePath ?? displayPath;
+    const destAbsPath = resolveFsPath(destDisplay, cwd);
+
+    if (hunk.movePath) {
+      ensureParentDir(destAbsPath, destDisplay);
+      writeFileOrThrow(destAbsPath, destDisplay, applied.newContents);
+      removeOriginalOrThrow(absPath, displayPath);
+    } else {
+      writeFileOrThrow(absPath, displayPath, applied.newContents);
+    }
+
+    modified.push(destDisplay);
+    files.push({
+      path: destDisplay,
+      status: "modified",
+      moveFrom: hunk.movePath ? displayPath : undefined,
+      moveTo: hunk.movePath ? destDisplay : undefined,
+      unifiedDiff: buildUpdateDiff(
+        hunk.movePath ? displayPath : displayPath,
+        destDisplay,
+        applied.originalLines,
+        applied.newLines,
+        applied.replacements,
+      ),
+    });
+  }
+
+  return {
+    affected: { added, modified, deleted },
+    details: { added, modified, deleted, files },
+  };
+}
+
+function deriveNewContentsFromChunks(
+  absPath: string,
+  displayPath: string,
+  chunks: UpdateFileChunk[],
+): AppliedPatch {
+  let originalContents: string;
+  try {
+    originalContents = fs.readFileSync(absPath, "utf-8");
+  } catch (err) {
+    const message = formatReadError("Failed to read file to update", displayPath, err);
+    throwError(message);
+  }
+
+  const originalLines = originalContents.split("\n");
+  if (originalLines.length > 0 && originalLines[originalLines.length - 1] === "") {
+    originalLines.pop();
+  }
+
+  const replacements = computeReplacements(originalLines, displayPath, chunks);
+  let newLines = applyReplacements([...originalLines], replacements);
+  if (newLines.length === 0 || newLines[newLines.length - 1] !== "") {
+    newLines = [...newLines, ""];
+  }
+  const newContents = newLines.join("\n");
+
+  const newLinesForDiff = newLines.length > 0 && newLines[newLines.length - 1] === ""
+    ? newLines.slice(0, -1)
+    : newLines;
+
+  return {
+    originalContents,
+    newContents,
+    replacements,
+    originalLines,
+    newLines: newLinesForDiff,
+  };
+}
+
+function computeReplacements(originalLines: string[], displayPath: string, chunks: UpdateFileChunk[]): Replacement[] {
+  const replacements: Replacement[] = [];
+  let lineIndex = 0;
+
+  for (const chunk of chunks) {
+    if (chunk.changeContext) {
+      const ctxIndex = seekSequence(originalLines, [chunk.changeContext], lineIndex, false);
+      if (ctxIndex === null) {
+        throwError(`Failed to find context '${chunk.changeContext}' in ${displayPath}`);
+      }
+      lineIndex = ctxIndex + 1;
+    }
+
+    if (chunk.oldLines.length === 0) {
+      const insertionIndex =
+        originalLines.length > 0 && originalLines[originalLines.length - 1] === ""
+          ? originalLines.length - 1
+          : originalLines.length;
+      replacements.push({ startIndex: insertionIndex, oldLen: 0, newLines: [...chunk.newLines] });
+      continue;
+    }
+
+    let pattern = chunk.oldLines;
+    let newSlice = chunk.newLines;
+    let found = seekSequence(originalLines, pattern, lineIndex, chunk.isEndOfFile);
+
+    if (found === null && pattern.length > 0 && pattern[pattern.length - 1] === "") {
+      pattern = pattern.slice(0, -1);
+      if (newSlice.length > 0 && newSlice[newSlice.length - 1] === "") {
+        newSlice = newSlice.slice(0, -1);
+      }
+      found = seekSequence(originalLines, pattern, lineIndex, chunk.isEndOfFile);
+    }
+
+    if (found !== null) {
+      replacements.push({ startIndex: found, oldLen: pattern.length, newLines: [...newSlice] });
+      lineIndex = found + pattern.length;
+    } else {
+      throwError(`Failed to find expected lines in ${displayPath}:\n${chunk.oldLines.join("\n")}`);
+    }
+  }
+
+  replacements.sort((a, b) => a.startIndex - b.startIndex);
+  return replacements;
+}
+
+function applyReplacements(lines: string[], replacements: Replacement[]): string[] {
+  for (let i = replacements.length - 1; i >= 0; i -= 1) {
+    const { startIndex, oldLen, newLines } = replacements[i];
+    lines.splice(startIndex, oldLen, ...newLines);
+  }
+  return lines;
+}
+
+function seekSequence(lines: string[], pattern: string[], start: number, eof: boolean): number | null {
+  if (pattern.length === 0) {
+    return start;
+  }
+
+  if (pattern.length > lines.length) {
+    return null;
+  }
+
+  const searchStart = eof && lines.length >= pattern.length ? lines.length - pattern.length : start;
+  const lastStart = lines.length - pattern.length;
+
+  for (let i = searchStart; i <= lastStart; i += 1) {
+    if (arraysEqual(lines, pattern, i)) {
+      return i;
+    }
+  }
+
+  for (let i = searchStart; i <= lastStart; i += 1) {
+    let ok = true;
+    for (let p = 0; p < pattern.length; p += 1) {
+      if (lines[i + p].trimEnd() !== pattern[p].trimEnd()) {
+        ok = false;
+        break;
+      }
+    }
+    if (ok) return i;
+  }
+
+  for (let i = searchStart; i <= lastStart; i += 1) {
+    let ok = true;
+    for (let p = 0; p < pattern.length; p += 1) {
+      if (lines[i + p].trim() !== pattern[p].trim()) {
+        ok = false;
+        break;
+      }
+    }
+    if (ok) return i;
+  }
+
+  for (let i = searchStart; i <= lastStart; i += 1) {
+    let ok = true;
+    for (let p = 0; p < pattern.length; p += 1) {
+      if (normalizeLine(lines[i + p]) !== normalizeLine(pattern[p])) {
+        ok = false;
+        break;
+      }
+    }
+    if (ok) return i;
+  }
+
+  return null;
+}
+
+function arraysEqual(lines: string[], pattern: string[], startIndex: number): boolean {
+  for (let i = 0; i < pattern.length; i += 1) {
+    if (lines[startIndex + i] !== pattern[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function normalizeLine(input: string): string {
+  return input
+    .trim()
+    .split("")
+    .map((char) => {
+      switch (char) {
+        case "\u2010":
+        case "\u2011":
+        case "\u2012":
+        case "\u2013":
+        case "\u2014":
+        case "\u2015":
+        case "\u2212":
+          return "-";
+        case "\u2018":
+        case "\u2019":
+        case "\u201A":
+        case "\u201B":
+          return "'";
+        case "\u201C":
+        case "\u201D":
+        case "\u201E":
+        case "\u201F":
+          return "\"";
+        case "\u00A0":
+        case "\u2002":
+        case "\u2003":
+        case "\u2004":
+        case "\u2005":
+        case "\u2006":
+        case "\u2007":
+        case "\u2008":
+        case "\u2009":
+        case "\u200A":
+        case "\u202F":
+        case "\u205F":
+        case "\u3000":
+          return " ";
+        default:
+          return char;
+      }
+    })
+    .join("");
+}
+
+function formatSummary(affected: AffectedPaths): string {
+  const lines: string[] = ["Success. Updated the following files:"];
+  for (const filePath of affected.added) {
+    lines.push(`A ${filePath}`);
+  }
+  for (const filePath of affected.modified) {
+    lines.push(`M ${filePath}`);
+  }
+  for (const filePath of affected.deleted) {
+    lines.push(`D ${filePath}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function buildAddDiff(displayPath: string, contents: string): string {
+  const lines = splitDiffLines(contents);
+  const header = [
+    `diff --git a/${displayPath} b/${displayPath}`,
+    "--- /dev/null",
+    `+++ b/${displayPath}`,
+  ];
+  const hunk = buildSimpleHunk(0, 0, 1, lines.length, [], lines, []);
+  return [...header, hunk].join("\n");
+}
+
+function buildDeleteDiff(displayPath: string, contents: string): string {
+  const lines = splitDiffLines(contents);
+  const header = [
+    `diff --git a/${displayPath} b/${displayPath}`,
+    `--- a/${displayPath}`,
+    "+++ /dev/null",
+  ];
+  const hunk = buildSimpleHunk(1, lines.length, 0, 0, lines, [], []);
+  return [...header, hunk].join("\n");
+}
+
+function buildUpdateDiff(
+  oldPath: string,
+  newPath: string,
+  originalLines: string[],
+  newLines: string[],
+  replacements: Replacement[],
+): string {
+  const header = [
+    `diff --git a/${oldPath} b/${newPath}`,
+    `--- a/${oldPath}`,
+    `+++ b/${newPath}`,
+  ];
+  const hunks = buildReplacementHunks(originalLines, newLines, replacements, 1);
+  return [...header, ...hunks].join("\n");
+}
+
+function buildReplacementHunks(
+  originalLines: string[],
+  newLines: string[],
+  replacements: Replacement[],
+  context: number,
+): string[] {
+  const hunks: string[] = [];
+  let delta = 0;
+
+  for (const replacement of replacements) {
+    const oldStart = replacement.startIndex;
+    const oldEnd = replacement.startIndex + replacement.oldLen;
+    const contextStart = Math.max(0, oldStart - context);
+    const contextEnd = Math.min(originalLines.length, oldEnd + context);
+    const contextBefore = originalLines.slice(contextStart, oldStart);
+    const contextAfter = originalLines.slice(oldEnd, contextEnd);
+    const newContextStart = contextStart + delta;
+    const oldHunkLen = contextBefore.length + replacement.oldLen + contextAfter.length;
+    const newHunkLen = contextBefore.length + replacement.newLines.length + contextAfter.length;
+    const hunkLines: string[] = [];
+
+    hunkLines.push(`@@ -${contextStart + 1},${oldHunkLen} +${newContextStart + 1},${newHunkLen} @@`);
+    for (const line of contextBefore) {
+      hunkLines.push(` ${line}`);
+    }
+    for (const line of originalLines.slice(oldStart, oldEnd)) {
+      hunkLines.push(`-${line}`);
+    }
+    for (const line of replacement.newLines) {
+      hunkLines.push(`+${line}`);
+    }
+    for (const line of contextAfter) {
+      hunkLines.push(` ${line}`);
+    }
+
+    hunks.push(hunkLines.join("\n"));
+    delta += replacement.newLines.length - replacement.oldLen;
+  }
+
+  return hunks;
+}
+
+function buildSimpleHunk(
+  oldStart: number,
+  oldLen: number,
+  newStart: number,
+  newLen: number,
+  removed: string[],
+  added: string[],
+  context: string[],
+): string {
+  const hunkLines: string[] = [];
+  hunkLines.push(`@@ -${oldStart},${oldLen} +${newStart},${newLen} @@`);
+  for (const line of context) {
+    hunkLines.push(` ${line}`);
+  }
+  for (const line of removed) {
+    hunkLines.push(`-${line}`);
+  }
+  for (const line of added) {
+    hunkLines.push(`+${line}`);
+  }
+  return hunkLines.join("\n");
+}
+
+function splitDiffLines(contents: string): string[] {
+  if (contents === "") return [];
+  const lines = contents.split("\n");
+  if (lines.length > 0 && lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+  return lines;
+}
+
+function resolveFsPath(displayPath: string, cwd: string): string {
+  const resolvedCwd = path.resolve(cwd);
+  const resolvedPath = path.isAbsolute(displayPath)
+    ? path.normalize(displayPath)
+    : path.resolve(resolvedCwd, displayPath);
+
+  if (!isPathWithinRoot(resolvedCwd, resolvedPath)) {
+    throwError("patch rejected: writing outside of the project; rejected by user approval settings");
+  }
+
+  return resolvedPath;
+}
+
+function isPathWithinRoot(root: string, target: string): boolean {
+  const relative = path.relative(root, target);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function ensureParentDir(absPath: string, displayPath: string): void {
+  const parent = path.dirname(absPath);
+  if (!parent || parent === "." || parent === absPath) {
+    return;
+  }
+  if (!fs.existsSync(parent)) {
+    try {
+      fs.mkdirSync(parent, { recursive: true });
+    } catch (err) {
+      const message = formatIoError("Failed to create parent directories for", displayPath, err);
+      throwError(message);
+    }
+  }
+}
+
+function writeFileOrThrow(absPath: string, displayPath: string, contents: string): void {
+  try {
+    fs.writeFileSync(absPath, contents);
+  } catch (err) {
+    const message = formatIoError("Failed to write file", displayPath, err);
+    throwError(message);
+  }
+}
+
+function deleteFileOrThrow(absPath: string, displayPath: string): void {
+  try {
+    fs.rmSync(absPath);
+  } catch {
+    throwError(`Failed to delete file ${displayPath}`);
+  }
+}
+
+function removeOriginalOrThrow(absPath: string, displayPath: string): void {
+  try {
+    fs.rmSync(absPath);
+  } catch (err) {
+    const message = formatIoError("Failed to remove original", displayPath, err);
+    throwError(message);
+  }
+}
+
+function readFileOptional(absPath: string): string {
+  try {
+    return fs.readFileSync(absPath, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+function formatReadError(prefix: string, displayPath: string, err: unknown): string {
+  const osMessage = formatOsError(err);
+  return `${prefix} ${displayPath}: ${osMessage}`;
+}
+
+function formatIoError(prefix: string, displayPath: string, err: unknown): string {
+  const osMessage = formatOsError(err);
+  return `${prefix} ${displayPath}: ${osMessage}`;
+}
+
+function formatOsError(err: unknown): string {
+  if (err && typeof err === "object" && "code" in err) {
+    const code = String((err as NodeJS.ErrnoException).code);
+    if (code === "ENOENT") {
+      return "No such file or directory (os error 2)";
+    }
+    if (code === "EACCES") {
+      return "Permission denied (os error 13)";
+    }
+    if (code === "EISDIR") {
+      return "Is a directory (os error 21)";
+    }
+  }
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}
+
+function throwError(message: string): never {
+  throw new Error(`${message}\n`);
+}

--- a/apply-patch-tool/tool-output.ts
+++ b/apply-patch-tool/tool-output.ts
@@ -1,0 +1,11 @@
+import type { ApplyPatchResult } from "./patch.js";
+
+export function buildToolOutput(result: ApplyPatchResult): string {
+  const summary = result.summary;
+  const diffs = result.details.files.map((file) => file.unifiedDiff).filter((diff) => diff !== "");
+  if (diffs.length === 0) {
+    return summary;
+  }
+
+  return `${summary}\n${diffs.join("\n\n")}\n`;
+}

--- a/docs/design/pi-apply-patch-design.md
+++ b/docs/design/pi-apply-patch-design.md
@@ -1,0 +1,60 @@
+# Apply Patch Tool + Prompt Steering (pi-mono)
+
+## Overview
+- Add an `apply_patch` tool that mirrors Codex’s patch format and behavior for safe, single‑file (or multi‑file) edits.
+- Provide system‑prompt steering that encourages `apply_patch` usage and documents the patch format.
+
+## Motivation
+- Parity with Codex tooling and guidance improves model behavior consistency across projects.
+- Patch‑style edits are safer and more auditable than free‑form edits for complex changes.
+- Prompt steering can be enabled per project without needing full core changes.
+
+## Proposed Solution
+### Apply_patch tool (Codex‑style)
+- Implement a tool named `apply_patch` that accepts a single `patchText` parameter.
+- Support the Codex envelope format:
+  - `*** Begin Patch` / `*** End Patch`
+  - `*** Add File:` / `*** Delete File:` / `*** Update File:` with optional `*** Move to:`
+  - `@@` hunks with `+`, `-`, and space‑prefixed lines
+- Validate paths to stay within the session `cwd` (reject absolute paths and path traversal).
+- Apply file operations with safe defaults (create parent directories for adds/moves; keep trailing newline).
+- Return a summary and unified diffs in tool output (plain text), plus per‑file diff metadata for UI rendering.
+
+### Prompt steering (appendable)
+- Add Codex‑style guidance text that:
+  - Encourages `apply_patch` for single‑file edits.
+  - Discourages `apply_patch` for generated output or bulk scripted changes.
+  - Documents the patch grammar and example usage.
+- Use `APPEND_SYSTEM.md` or `--append-system-prompt` to inject this guidance without core changes.
+- Optionally allow extensions to inject prompt text via `before_agent_start` for per‑model gating.
+
+## Files to Update
+**Extension‑only approach (no core changes)**
+- `/tmp/pi-extensions/apply-patch-extension.ts` (new): registers `apply_patch` tool.
+- Project or user prompt append file:
+  - `<repo>/.pi/APPEND_SYSTEM.md` or `~/.pi/agent/APPEND_SYSTEM.md`
+
+**Core approach (built‑in tool)**
+- `packages/coding-agent/src/core/tools/apply-patch.ts` (new tool implementation)
+- `packages/coding-agent/src/core/tools/index.ts` (export + include in `allTools`)
+- `packages/coding-agent/src/core/system-prompt.ts` (tool description + guidance)
+- `packages/coding-agent/docs/extensions.md` or `docs/sdk.md` (document tool + format)
+- Add tests under `packages/coding-agent/test` for patch parsing and application
+
+## Implementation Steps
+1. Implement patch parser + file operations with Codex‑style grammar.
+2. Register the tool (extension or core) and expose it in active tools.
+3. Add prompt steering via `APPEND_SYSTEM.md` (or core prompt text).
+4. Add tests for add/update/delete/move and error cases.
+
+## Open Questions
+- None.
+
+## Alternatives Considered
+- **Stay with edit/write only:** Simpler, but loses Codex parity and patch safety.
+- **Extension tool only:** Fastest path; lacks automatic inclusion in system prompt tool list.
+- **Core tool:** Best UX and prompt integration, but requires core changes + tests.
+
+## Out of Scope
+- LSP diagnostics or IDE‑level validation after patch application.
+- Model‑specific tool gating baked into core (can be handled via extension rules).


### PR DESCRIPTION
## Summary
- add Codex-style apply_patch extension with prompt injection
- mirror Codex parsing/outputs, including unified diff text in tool output
- add tests for parser and tool output behavior

## Testing
- npm test (apply-patch-tool)
