### PR TITLE
Add agent-voice-adapter reminder extension and followup-rules design docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   - Design document at `toolwatch/docs/design/local-rules.md`
   - Bundled distribution via `npm run dist` (no npm install required at destination)
 - **toolwatch**: Collector accepts audit-only HTTP events (`X-Toolwatch-Audit: true`) and records them as approved without rule evaluation
+- **agent-voice-adapter-reminder**: Add extension for `kcosr/agent-voice-adapter` workflows with `/ava-mode`, `/ava-status`, `/ava-reminder mark-stopped`, and `agent_voice_adapter_session_done` tool
 
 ### Changed
 - **assistant**: Add list/instance/include pickers, scoped search with all-list/instance modes, and persisted picker state

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   - Design document at `toolwatch/docs/design/local-rules.md`
   - Bundled distribution via `npm run dist` (no npm install required at destination)
 - **toolwatch**: Collector accepts audit-only HTTP events (`X-Toolwatch-Audit: true`) and records them as approved without rule evaluation
-- **agent-voice-adapter-reminder**: Add extension for `kcosr/agent-voice-adapter` workflows with `/ava-mode`, `/ava-status`, `/ava-reminder mark-stopped`, and `agent_voice_adapter_session_done` tool
+- **agent-voice-adapter-reminder**: Add extension for `kcosr/agent-voice-adapter` workflows with session-scoped `/ava-mode`, persisted `/ava-set` defaults (`default-mode`, `max-reminders`), `/ava-status`, `/ava-reminder mark-stopped`, `agent_voice_adapter_session_done` tool, and per-session max reminder counting
 
 ### Changed
 - **assistant**: Add list/instance/include pickers, scoped search with all-list/instance modes, and persisted picker state

--- a/README.md
+++ b/README.md
@@ -48,5 +48,6 @@ Reload pi after installing.
 | [assistant](assistant/) | Browse Assistant lists and notes with fuzzy search and inject selections via `/assistant`. |
 | [skill-picker](skill-picker/) | Command palette for selecting and queueing skills explicitly via `/skill` command. Hard fork of [pi-skill-palette](https://github.com/nicobailon/pi-skill-palette). |
 | [toolwatch](toolwatch/) | Tool call auditing and approval system. Log all tool calls to SQLite, block dangerous commands, require manual approval for sensitive operations. |
+| [agent-voice-adapter-reminder](agent-voice-adapter-reminder/) | Tracks agent completion and nudges voice-first flows to end with interactive `agent-voice-adapter-cli` turns. |
 
 See each extension's README for configuration details.

--- a/agent-voice-adapter-reminder/README.md
+++ b/agent-voice-adapter-reminder/README.md
@@ -9,7 +9,9 @@ This extension is designed for workflows using
 ## What it does
 
 - Adds mode control via:
-  - `/ava-mode off|auto|on`
+  - `/ava-mode off|auto|on` (per-session)
+  - `/ava-set default-mode <off|auto|on>`
+  - `/ava-set max-reminders <n>`
   - `/ava-status`
   - `/ava-reminder mark-stopped`
 - Adds an LLM-callable tool:
@@ -22,10 +24,21 @@ This extension is designed for workflows using
 - `off`: never auto-nudge.
 - `auto` (default): nudge unless the **last successful tool call** in the run was
   interactive `agent-voice-adapter-cli(.js)` (without `--no-wait`).
-- `on`: always nudge at `agent_end` (unless marked stopped).
+- `on`: nudge at `agent_end` while under the session's max reminder count (unless marked stopped).
 
 `mark-stopped` and `agent_voice_adapter_session_done` suppress nudges until the next
 real user input (`input.source !== "extension"`).
+
+Each session tracks reminder attempts and enforces a max count. The reminder counter
+resets on the next real user input.
+
+## Session scope and defaults
+
+- `/ava-mode` is scoped to the active session.
+- `/ava-set default-mode ...` sets the mode default used when a session is first seen by the extension.
+- `/ava-set max-reminders ...` sets the default max reminders for new sessions.
+- Defaults are saved to:
+  - `~/.pi/agent/extensions/agent-voice-adapter-reminder/config.json`
 
 ## Installation
 
@@ -41,8 +54,7 @@ cp -R /path/to/pi-extensions/agent-voice-adapter-reminder ~/.pi/agent/extensions
 
 Yes — because the voice interaction is invoked through the `bash` tool, the extension
 inspects bash tool calls and checks whether the command contains
-`agent-voice-adapter-cli` / `agent-voice-adapter-cli.js` and does **not** include
-`--no-wait`.
+`agent-voice-adapter-cli.js` and does **not** include `--no-wait`.
 
 That is currently the reliable way to identify interactive voice turns from extension
 events.

--- a/agent-voice-adapter-reminder/README.md
+++ b/agent-voice-adapter-reminder/README.md
@@ -1,0 +1,57 @@
+# agent-voice-adapter-reminder
+
+Keep pi voice-first by nudging the agent to end with an interactive
+`agent-voice-adapter-cli.js` prompt when needed.
+
+This extension is designed for workflows using
+[`kcosr/agent-voice-adapter`](https://github.com/kcosr/agent-voice-adapter).
+
+## What it does
+
+- Adds mode control via:
+  - `/ava-mode off|auto|on`
+  - `/ava-status`
+  - `/ava-reminder mark-stopped`
+- Adds an LLM-callable tool:
+  - `agent_voice_adapter_session_done`
+- On `agent_end`, conditionally sends a follow-up instruction to use
+  `agent-voice-adapter-cli.js` in interactive mode.
+
+## Mode behavior
+
+- `off`: never auto-nudge.
+- `auto` (default): nudge unless the **last successful tool call** in the run was
+  interactive `agent-voice-adapter-cli(.js)` (without `--no-wait`).
+- `on`: always nudge at `agent_end` (unless marked stopped).
+
+`mark-stopped` and `agent_voice_adapter_session_done` suppress nudges until the next
+real user input (`input.source !== "extension"`).
+
+## Installation
+
+1. Copy the extension into your pi extensions directory:
+
+```bash
+cp -R /path/to/pi-extensions/agent-voice-adapter-reminder ~/.pi/agent/extensions/agent-voice-adapter-reminder
+```
+
+2. Restart pi (or run `/reload`).
+
+## How command detection works
+
+Yes — because the voice interaction is invoked through the `bash` tool, the extension
+inspects bash tool calls and checks whether the command contains
+`agent-voice-adapter-cli` / `agent-voice-adapter-cli.js` and does **not** include
+`--no-wait`.
+
+That is currently the reliable way to identify interactive voice turns from extension
+events.
+
+## Development
+
+Run logic tests:
+
+```bash
+cd agent-voice-adapter-reminder
+npm test
+```

--- a/agent-voice-adapter-reminder/index.ts
+++ b/agent-voice-adapter-reminder/index.ts
@@ -1,64 +1,157 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { isToolCallEventType } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { isAvaMode, isInteractiveVoiceAdapterCommand, shouldQueueVoiceFollowUp } from "./logic.js";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 
 type AvaMode = "off" | "auto" | "on";
+
+interface AvaConfig {
+	defaultMode?: AvaMode;
+	defaultMaxReminders?: number;
+}
+
+interface SessionState {
+	mode: AvaMode;
+	stoppedUntilUserInput: boolean;
+	lastSuccessfulToolWasInteractiveVoice: boolean;
+	interactiveVoiceToolCalls: Set<string>;
+	reminderCount: number;
+	maxReminders: number;
+}
 
 const AVA_FOLLOW_UP_PROMPT =
 	"Before you finish, prompt the user with agent-voice-adapter-cli.js in interactive mode (without --no-wait).";
 
+const CONFIG_PATH = path.join(
+	os.homedir(),
+	".pi",
+	"agent",
+	"extensions",
+	"agent-voice-adapter-reminder",
+	"config.json",
+);
+
+function parseNonNegativeInt(value: string): number | null {
+	if (!/^\d+$/.test(value)) return null;
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isFinite(parsed) || parsed < 0) return null;
+	return parsed;
+}
+
+function loadConfig(): AvaConfig {
+	try {
+		if (!fs.existsSync(CONFIG_PATH)) return {};
+		const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
+		const parsed = JSON.parse(raw) as AvaConfig;
+		const config: AvaConfig = {};
+		if (parsed.defaultMode && isAvaMode(parsed.defaultMode)) {
+			config.defaultMode = parsed.defaultMode;
+		}
+		if (typeof parsed.defaultMaxReminders === "number" && parsed.defaultMaxReminders >= 0) {
+			config.defaultMaxReminders = Math.floor(parsed.defaultMaxReminders);
+		}
+		return config;
+	} catch {
+		return {};
+	}
+}
+
+function saveConfig(config: AvaConfig): { success: true } | { success: false; error: string } {
+	try {
+		fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
+		fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", "utf-8");
+		return { success: true };
+	} catch (error) {
+		return {
+			success: false,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+function getSessionKey(ctx: ExtensionContext): string {
+	return ctx.sessionManager.getSessionFile() ?? "__ephemeral__";
+}
+
 export default function (pi: ExtensionAPI) {
-	let mode: AvaMode = "auto";
-	let stoppedUntilUserInput = false;
-	let lastSuccessfulToolWasInteractiveVoice = false;
+	const config = loadConfig();
+	let defaultMode: AvaMode = config.defaultMode ?? "auto";
+	let defaultMaxReminders = config.defaultMaxReminders ?? 2;
 
-	const interactiveVoiceToolCalls = new Set<string>();
+	const sessionStates = new Map<string, SessionState>();
 
-	pi.on("input", async (event) => {
+	const getSessionState = (ctx: ExtensionContext): SessionState => {
+		const key = getSessionKey(ctx);
+		let state = sessionStates.get(key);
+		if (!state) {
+			state = {
+				mode: defaultMode,
+				stoppedUntilUserInput: false,
+				lastSuccessfulToolWasInteractiveVoice: false,
+				interactiveVoiceToolCalls: new Set<string>(),
+				reminderCount: 0,
+				maxReminders: defaultMaxReminders,
+			};
+			sessionStates.set(key, state);
+		}
+		return state;
+	};
+
+	pi.on("input", async (event, ctx) => {
 		if (event.source !== "extension") {
-			stoppedUntilUserInput = false;
+			const state = getSessionState(ctx);
+			state.stoppedUntilUserInput = false;
+			state.reminderCount = 0;
 		}
 		return { action: "continue" };
 	});
 
-	pi.on("agent_start", async () => {
-		lastSuccessfulToolWasInteractiveVoice = false;
-		interactiveVoiceToolCalls.clear();
+	pi.on("agent_start", async (_event, ctx) => {
+		const state = getSessionState(ctx);
+		state.lastSuccessfulToolWasInteractiveVoice = false;
+		state.interactiveVoiceToolCalls.clear();
 	});
 
-	pi.on("tool_call", async (event) => {
+	pi.on("tool_call", async (event, ctx) => {
 		if (!isToolCallEventType("bash", event)) return;
-		if (isInteractiveVoiceAdapterCommand(event.input.command)) {
-			interactiveVoiceToolCalls.add(event.toolCallId);
-		}
+		if (!isInteractiveVoiceAdapterCommand(event.input.command)) return;
+		const state = getSessionState(ctx);
+		state.interactiveVoiceToolCalls.add(event.toolCallId);
 	});
 
-	pi.on("tool_execution_end", async (event) => {
-		const wasInteractiveVoice = interactiveVoiceToolCalls.has(event.toolCallId);
-		interactiveVoiceToolCalls.delete(event.toolCallId);
+	pi.on("tool_execution_end", async (event, ctx) => {
+		const state = getSessionState(ctx);
+		const wasInteractiveVoice = state.interactiveVoiceToolCalls.has(event.toolCallId);
+		state.interactiveVoiceToolCalls.delete(event.toolCallId);
 		if (event.isError) return;
-		lastSuccessfulToolWasInteractiveVoice = wasInteractiveVoice;
+		state.lastSuccessfulToolWasInteractiveVoice = wasInteractiveVoice;
 	});
 
-	pi.on("agent_end", async () => {
+	pi.on("agent_end", async (_event, ctx) => {
+		const state = getSessionState(ctx);
 		const shouldQueue = shouldQueueVoiceFollowUp({
-			mode,
-			stoppedUntilUserInput,
-			lastSuccessfulToolWasInteractiveVoice,
+			mode: state.mode,
+			stoppedUntilUserInput: state.stoppedUntilUserInput,
+			lastSuccessfulToolWasInteractiveVoice: state.lastSuccessfulToolWasInteractiveVoice,
+			reminderCount: state.reminderCount,
+			maxReminders: state.maxReminders,
 		});
 		if (!shouldQueue) return;
 
-		stoppedUntilUserInput = true;
+		state.reminderCount += 1;
 		pi.sendUserMessage(AVA_FOLLOW_UP_PROMPT);
 	});
 
 	pi.registerCommand("ava-mode", {
-		description: "Set agent voice adapter mode: off, auto, on",
+		description: "Set agent voice adapter mode (per-session): off, auto, on",
 		handler: async (args, ctx) => {
+			const state = getSessionState(ctx);
 			const value = (args ?? "").trim().toLowerCase();
 			if (!value) {
-				ctx.ui.notify(`ava-mode is ${mode}`, "info");
+				ctx.ui.notify(`ava-mode is ${state.mode} (session-scoped)`, "info");
 				return;
 			}
 
@@ -67,31 +160,84 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 
-			mode = value as AvaMode;
-			ctx.ui.notify(`ava-mode set to ${mode}`, "info");
+			state.mode = value as AvaMode;
+			ctx.ui.notify(`ava-mode set to ${state.mode} for this session`, "info");
+		},
+	});
+
+	pi.registerCommand("ava-set", {
+		description: "Set default config: /ava-set default-mode <off|auto|on> or /ava-set max-reminders <n>",
+		handler: async (args, ctx) => {
+			const parts = (args ?? "").trim().split(/\s+/).filter(Boolean);
+			if (parts.length !== 2) {
+				ctx.ui.notify("Usage: /ava-set default-mode <off|auto|on> OR /ava-set max-reminders <n>", "warning");
+				return;
+			}
+
+			const [key, value] = parts;
+			if (key === "default-mode") {
+				if (!isAvaMode(value)) {
+					ctx.ui.notify("Usage: /ava-set default-mode <off|auto|on>", "warning");
+					return;
+				}
+				defaultMode = value as AvaMode;
+				const result = saveConfig({ defaultMode, defaultMaxReminders });
+				if (!result.success) {
+					ctx.ui.notify(`Failed to save config: ${result.error}`, "error");
+					return;
+				}
+				ctx.ui.notify(
+					`ava-set saved default-mode=${defaultMode} (applies to new sessions)`,
+					"info",
+				);
+				return;
+			}
+
+			if (key === "max-reminders") {
+				const parsed = parseNonNegativeInt(value);
+				if (parsed === null) {
+					ctx.ui.notify("Usage: /ava-set max-reminders <non-negative integer>", "warning");
+					return;
+				}
+				defaultMaxReminders = parsed;
+				const result = saveConfig({ defaultMode, defaultMaxReminders });
+				if (!result.success) {
+					ctx.ui.notify(`Failed to save config: ${result.error}`, "error");
+					return;
+				}
+				ctx.ui.notify(
+					`ava-set saved max-reminders=${defaultMaxReminders} (applies to new sessions)`,
+					"info",
+				);
+				return;
+			}
+
+			ctx.ui.notify("Unknown key. Valid keys: default-mode, max-reminders", "warning");
 		},
 	});
 
 	pi.registerCommand("ava-status", {
-		description: "Show agent voice adapter reminder status",
+		description: "Show agent voice adapter reminder status for this session",
 		handler: async (_args, ctx) => {
+			const state = getSessionState(ctx);
 			ctx.ui.notify(
-				`ava-status mode=${mode}, stoppedUntilUserInput=${stoppedUntilUserInput}, lastSuccessfulToolWasInteractiveVoice=${lastSuccessfulToolWasInteractiveVoice}`,
+				`ava-status mode=${state.mode}, defaultMode=${defaultMode}, reminderCount=${state.reminderCount}/${state.maxReminders}, defaultMaxReminders=${defaultMaxReminders}, stoppedUntilUserInput=${state.stoppedUntilUserInput}, lastSuccessfulToolWasInteractiveVoice=${state.lastSuccessfulToolWasInteractiveVoice}`,
 				"info",
 			);
 		},
 	});
 
 	pi.registerCommand("ava-reminder", {
-		description: "Control reminder cycle (mark-stopped)",
+		description: "Control reminder cycle for this session (mark-stopped)",
 		handler: async (args, ctx) => {
+			const state = getSessionState(ctx);
 			const value = (args ?? "").trim().toLowerCase();
 			if (value !== "mark-stopped") {
 				ctx.ui.notify("Usage: /ava-reminder mark-stopped", "warning");
 				return;
 			}
 
-			stoppedUntilUserInput = true;
+			state.stoppedUntilUserInput = true;
 			ctx.ui.notify("AVA session marked done until next user input", "info");
 		},
 	});
@@ -101,16 +247,21 @@ export default function (pi: ExtensionAPI) {
 		label: "Agent Voice Adapter Session Done",
 		description: "Indicate the current agent voice adapter interaction is complete for this user request.",
 		parameters: Type.Object({}),
-		async execute() {
-			stoppedUntilUserInput = true;
+		async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
+			const state = getSessionState(ctx);
+			state.stoppedUntilUserInput = true;
 			return {
 				content: [
 					{ type: "text", text: "Agent voice adapter session marked done until next user input." },
 				],
 				details: {
-					mode,
-					stoppedUntilUserInput,
-					lastSuccessfulToolWasInteractiveVoice,
+					mode: state.mode,
+					defaultMode,
+					reminderCount: state.reminderCount,
+					maxReminders: state.maxReminders,
+					defaultMaxReminders,
+					stoppedUntilUserInput: state.stoppedUntilUserInput,
+					lastSuccessfulToolWasInteractiveVoice: state.lastSuccessfulToolWasInteractiveVoice,
 				},
 			};
 		},

--- a/agent-voice-adapter-reminder/index.ts
+++ b/agent-voice-adapter-reminder/index.ts
@@ -1,0 +1,118 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { isToolCallEventType } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import { isAvaMode, isInteractiveVoiceAdapterCommand, shouldQueueVoiceFollowUp } from "./logic.js";
+
+type AvaMode = "off" | "auto" | "on";
+
+const AVA_FOLLOW_UP_PROMPT =
+	"Before you finish, prompt the user with agent-voice-adapter-cli.js in interactive mode (without --no-wait).";
+
+export default function (pi: ExtensionAPI) {
+	let mode: AvaMode = "auto";
+	let stoppedUntilUserInput = false;
+	let lastSuccessfulToolWasInteractiveVoice = false;
+
+	const interactiveVoiceToolCalls = new Set<string>();
+
+	pi.on("input", async (event) => {
+		if (event.source !== "extension") {
+			stoppedUntilUserInput = false;
+		}
+		return { action: "continue" };
+	});
+
+	pi.on("agent_start", async () => {
+		lastSuccessfulToolWasInteractiveVoice = false;
+		interactiveVoiceToolCalls.clear();
+	});
+
+	pi.on("tool_call", async (event) => {
+		if (!isToolCallEventType("bash", event)) return;
+		if (isInteractiveVoiceAdapterCommand(event.input.command)) {
+			interactiveVoiceToolCalls.add(event.toolCallId);
+		}
+	});
+
+	pi.on("tool_execution_end", async (event) => {
+		const wasInteractiveVoice = interactiveVoiceToolCalls.has(event.toolCallId);
+		interactiveVoiceToolCalls.delete(event.toolCallId);
+		if (event.isError) return;
+		lastSuccessfulToolWasInteractiveVoice = wasInteractiveVoice;
+	});
+
+	pi.on("agent_end", async () => {
+		const shouldQueue = shouldQueueVoiceFollowUp({
+			mode,
+			stoppedUntilUserInput,
+			lastSuccessfulToolWasInteractiveVoice,
+		});
+		if (!shouldQueue) return;
+
+		stoppedUntilUserInput = true;
+		pi.sendUserMessage(AVA_FOLLOW_UP_PROMPT);
+	});
+
+	pi.registerCommand("ava-mode", {
+		description: "Set agent voice adapter mode: off, auto, on",
+		handler: async (args, ctx) => {
+			const value = (args ?? "").trim().toLowerCase();
+			if (!value) {
+				ctx.ui.notify(`ava-mode is ${mode}`, "info");
+				return;
+			}
+
+			if (!isAvaMode(value)) {
+				ctx.ui.notify("Usage: /ava-mode off|auto|on", "warning");
+				return;
+			}
+
+			mode = value as AvaMode;
+			ctx.ui.notify(`ava-mode set to ${mode}`, "info");
+		},
+	});
+
+	pi.registerCommand("ava-status", {
+		description: "Show agent voice adapter reminder status",
+		handler: async (_args, ctx) => {
+			ctx.ui.notify(
+				`ava-status mode=${mode}, stoppedUntilUserInput=${stoppedUntilUserInput}, lastSuccessfulToolWasInteractiveVoice=${lastSuccessfulToolWasInteractiveVoice}`,
+				"info",
+			);
+		},
+	});
+
+	pi.registerCommand("ava-reminder", {
+		description: "Control reminder cycle (mark-stopped)",
+		handler: async (args, ctx) => {
+			const value = (args ?? "").trim().toLowerCase();
+			if (value !== "mark-stopped") {
+				ctx.ui.notify("Usage: /ava-reminder mark-stopped", "warning");
+				return;
+			}
+
+			stoppedUntilUserInput = true;
+			ctx.ui.notify("AVA session marked done until next user input", "info");
+		},
+	});
+
+	pi.registerTool({
+		name: "agent_voice_adapter_session_done",
+		label: "Agent Voice Adapter Session Done",
+		description: "Indicate the current agent voice adapter interaction is complete for this user request.",
+		parameters: Type.Object({}),
+		async execute() {
+			stoppedUntilUserInput = true;
+			return {
+				content: [
+					{ type: "text", text: "Agent voice adapter session marked done until next user input." },
+				],
+				details: {
+					mode,
+					stoppedUntilUserInput,
+					lastSuccessfulToolWasInteractiveVoice,
+				},
+			};
+		},
+	});
+}

--- a/agent-voice-adapter-reminder/logic.js
+++ b/agent-voice-adapter-reminder/logic.js
@@ -1,0 +1,25 @@
+export const AVA_MODES = ["off", "auto", "on"];
+
+const VOICE_CLI_PATTERN = /(^|[^\w-])agent-voice-adapter-cli(?:\.js)?(?=$|[^\w-])/;
+const NO_WAIT_PATTERN = /(^|\s)--no-wait(?=\s|$)/;
+
+export function isInteractiveVoiceAdapterCommand(command) {
+	if (typeof command !== "string") return false;
+	if (!VOICE_CLI_PATTERN.test(command)) return false;
+	return !NO_WAIT_PATTERN.test(command);
+}
+
+export function isAvaMode(value) {
+	return AVA_MODES.includes(value);
+}
+
+export function shouldQueueVoiceFollowUp({
+	mode,
+	stoppedUntilUserInput,
+	lastSuccessfulToolWasInteractiveVoice,
+}) {
+	if (mode === "off") return false;
+	if (stoppedUntilUserInput) return false;
+	if (mode === "auto" && lastSuccessfulToolWasInteractiveVoice) return false;
+	return true;
+}

--- a/agent-voice-adapter-reminder/logic.js
+++ b/agent-voice-adapter-reminder/logic.js
@@ -1,6 +1,6 @@
 export const AVA_MODES = ["off", "auto", "on"];
 
-const VOICE_CLI_PATTERN = /(^|[^\w-])agent-voice-adapter-cli(?:\.js)?(?=$|[^\w-])/;
+const VOICE_CLI_PATTERN = /(^|[^\w-])agent-voice-adapter-cli\.js(?=$|[^\w-])/;
 const NO_WAIT_PATTERN = /(^|\s)--no-wait(?=\s|$)/;
 
 export function isInteractiveVoiceAdapterCommand(command) {
@@ -17,9 +17,12 @@ export function shouldQueueVoiceFollowUp({
 	mode,
 	stoppedUntilUserInput,
 	lastSuccessfulToolWasInteractiveVoice,
+	reminderCount,
+	maxReminders,
 }) {
 	if (mode === "off") return false;
 	if (stoppedUntilUserInput) return false;
+	if (Number.isFinite(maxReminders) && maxReminders >= 0 && reminderCount >= maxReminders) return false;
 	if (mode === "auto" && lastSuccessfulToolWasInteractiveVoice) return false;
 	return true;
 }

--- a/agent-voice-adapter-reminder/logic.test.js
+++ b/agent-voice-adapter-reminder/logic.test.js
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isInteractiveVoiceAdapterCommand, shouldQueueVoiceFollowUp } from "./logic.js";
+
+test("detects interactive agent-voice-adapter CLI command", () => {
+	assert.equal(isInteractiveVoiceAdapterCommand('agent-voice-adapter-cli.js "Hello"'), true);
+	assert.equal(isInteractiveVoiceAdapterCommand('agent-voice-adapter-cli "Hello"'), true);
+});
+
+test("treats --no-wait as non-interactive", () => {
+	assert.equal(isInteractiveVoiceAdapterCommand('agent-voice-adapter-cli.js --no-wait "Done"'), false);
+	assert.equal(isInteractiveVoiceAdapterCommand('agent-voice-adapter-cli --no-wait "Done"'), false);
+});
+
+test("ignores unrelated bash commands", () => {
+	assert.equal(isInteractiveVoiceAdapterCommand('echo "hello"'), false);
+	assert.equal(isInteractiveVoiceAdapterCommand(""), false);
+});
+
+test("queues in auto mode when last successful tool was not interactive voice", () => {
+	assert.equal(
+		shouldQueueVoiceFollowUp({
+			mode: "auto",
+			stoppedUntilUserInput: false,
+			lastSuccessfulToolWasInteractiveVoice: false,
+		}),
+		true,
+	);
+});
+
+test("does not queue in auto mode when last successful tool was interactive voice", () => {
+	assert.equal(
+		shouldQueueVoiceFollowUp({
+			mode: "auto",
+			stoppedUntilUserInput: false,
+			lastSuccessfulToolWasInteractiveVoice: true,
+		}),
+		false,
+	);
+});
+
+test("does not queue when stopped until user input", () => {
+	assert.equal(
+		shouldQueueVoiceFollowUp({
+			mode: "on",
+			stoppedUntilUserInput: true,
+			lastSuccessfulToolWasInteractiveVoice: false,
+		}),
+		false,
+	);
+});
+
+test("off mode never queues", () => {
+	assert.equal(
+		shouldQueueVoiceFollowUp({
+			mode: "off",
+			stoppedUntilUserInput: false,
+			lastSuccessfulToolWasInteractiveVoice: false,
+		}),
+		false,
+	);
+});

--- a/agent-voice-adapter-reminder/logic.test.js
+++ b/agent-voice-adapter-reminder/logic.test.js
@@ -2,18 +2,25 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { isInteractiveVoiceAdapterCommand, shouldQueueVoiceFollowUp } from "./logic.js";
 
-test("detects interactive agent-voice-adapter CLI command", () => {
+test("detects interactive agent-voice-adapter-cli.js command", () => {
 	assert.equal(isInteractiveVoiceAdapterCommand('agent-voice-adapter-cli.js "Hello"'), true);
-	assert.equal(isInteractiveVoiceAdapterCommand('agent-voice-adapter-cli "Hello"'), true);
+	assert.equal(
+		isInteractiveVoiceAdapterCommand('node /home/kevin/.agents/skills/agent-voice-adapter-cli/agent-voice-adapter-cli.js "Hello"'),
+		true,
+	);
 });
 
 test("treats --no-wait as non-interactive", () => {
 	assert.equal(isInteractiveVoiceAdapterCommand('agent-voice-adapter-cli.js --no-wait "Done"'), false);
-	assert.equal(isInteractiveVoiceAdapterCommand('agent-voice-adapter-cli --no-wait "Done"'), false);
+	assert.equal(
+		isInteractiveVoiceAdapterCommand('node /home/kevin/.agents/skills/agent-voice-adapter-cli/agent-voice-adapter-cli.js --no-wait "Done"'),
+		false,
+	);
 });
 
 test("ignores unrelated bash commands", () => {
 	assert.equal(isInteractiveVoiceAdapterCommand('echo "hello"'), false);
+	assert.equal(isInteractiveVoiceAdapterCommand('agent-voice-adapter-cli "Hello"'), false);
 	assert.equal(isInteractiveVoiceAdapterCommand(""), false);
 });
 
@@ -23,6 +30,8 @@ test("queues in auto mode when last successful tool was not interactive voice", 
 			mode: "auto",
 			stoppedUntilUserInput: false,
 			lastSuccessfulToolWasInteractiveVoice: false,
+			reminderCount: 0,
+			maxReminders: 1,
 		}),
 		true,
 	);
@@ -34,6 +43,8 @@ test("does not queue in auto mode when last successful tool was interactive voic
 			mode: "auto",
 			stoppedUntilUserInput: false,
 			lastSuccessfulToolWasInteractiveVoice: true,
+			reminderCount: 0,
+			maxReminders: 1,
 		}),
 		false,
 	);
@@ -45,6 +56,21 @@ test("does not queue when stopped until user input", () => {
 			mode: "on",
 			stoppedUntilUserInput: true,
 			lastSuccessfulToolWasInteractiveVoice: false,
+			reminderCount: 0,
+			maxReminders: 2,
+		}),
+		false,
+	);
+});
+
+test("does not queue after max reminders reached", () => {
+	assert.equal(
+		shouldQueueVoiceFollowUp({
+			mode: "on",
+			stoppedUntilUserInput: false,
+			lastSuccessfulToolWasInteractiveVoice: false,
+			reminderCount: 2,
+			maxReminders: 2,
 		}),
 		false,
 	);
@@ -56,6 +82,8 @@ test("off mode never queues", () => {
 			mode: "off",
 			stoppedUntilUserInput: false,
 			lastSuccessfulToolWasInteractiveVoice: false,
+			reminderCount: 0,
+			maxReminders: 10,
 		}),
 		false,
 	);

--- a/agent-voice-adapter-reminder/package.json
+++ b/agent-voice-adapter-reminder/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "agent-voice-adapter-reminder",
+  "version": "0.1.0",
+  "description": "Ensure pi voice sessions end with an interactive agent-voice-adapter prompt when needed",
+  "main": "index.ts",
+  "type": "module",
+  "scripts": {
+    "test": "node --test logic.test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kcosr/pi-extensions"
+  },
+  "author": "kcosr",
+  "license": "MIT"
+}

--- a/session-followup-rules/DESIGN.md
+++ b/session-followup-rules/DESIGN.md
@@ -1,0 +1,183 @@
+# session-followup-rules: Design Draft
+
+## Goals
+
+1. Generalize end-of-run nudges beyond one specific tool/workflow.
+2. Keep loop prevention semantics (`stopped until next real user input`).
+3. Support multiple independent rules per session.
+4. Expose both command-based and interactive TUI-based configuration.
+5. Preserve a clean path for AVA compatibility.
+
+## Non-goals (v1)
+
+- Full DSL evaluator for arbitrary logic expressions.
+- Persistent cross-machine state sync.
+- Dynamic hot-reload of config without `/reload`.
+
+## Core concept
+
+A **rule** is evaluated at `agent_end`.
+
+If a rule is active and conditions indicate a follow-up is needed, the extension
+queues a follow-up message (usually via `pi.sendUserMessage(..., { deliverAs: "followUp" })`).
+
+Each rule has:
+
+- Static config (matching + behavior)
+- Runtime mode (`off|auto|on`)
+- Runtime state (`stoppedUntilUserInput`)
+
+## Rule schema (proposed)
+
+```json
+{
+  "id": "ava-end-prompt",
+  "label": "AVA end prompt",
+  "enabledByDefault": true,
+  "defaultMode": "auto",
+  "doneTool": {
+    "name": "session_rule_done",
+    "requiresRuleId": true
+  },
+  "followUp": {
+    "message": "Before you finish, prompt the user with agent-voice-adapter-cli.js in interactive mode.",
+    "deliverAs": "followUp"
+  },
+  "limits": {
+    "maxRemindersPerUserCycle": 1
+  },
+  "autoCondition": {
+    "strategy": "last-successful-tool-matches",
+    "toolMatch": {
+      "toolName": "bash",
+      "command": {
+        "includesAny": ["agent-voice-adapter-cli", "agent-voice-adapter-cli.js"],
+        "excludesAny": ["--no-wait"]
+      }
+    }
+  }
+}
+```
+
+## Runtime model
+
+Per rule runtime state:
+
+```ts
+{
+  mode: "off" | "auto" | "on";
+  stoppedUntilUserInput: boolean;
+  reminderCountInUserCycle: number;
+  maxRemindersPerUserCycle: number;
+  lastSuccessfulToolMatched: boolean;
+  matchedInLastTurn: boolean;
+  matchedInRun: boolean;
+}
+```
+
+Global state:
+
+- map of pending matched toolCallIds (for result correlation)
+- per-rule state map keyed by rule id
+
+## Event processing
+
+### `input`
+
+If `event.source !== "extension"`:
+
+- clear `stoppedUntilUserInput` for all rules
+- reset `reminderCountInUserCycle` for all rules
+- clear per-run/per-turn match accumulators for next cycle
+
+### `agent_start`
+
+- reset per-run/per-turn match accumulators
+
+### `tool_call`
+
+- evaluate call-level match candidates
+- cache `{ toolCallId -> matchingRuleIds }`
+
+### `tool_execution_end`
+
+- for successful executions, update rule runtime match state
+- track last successful tool and whether it matched each rule
+
+### `turn_end` (optional for v1)
+
+- update `matchedInLastTurn`
+
+### `agent_end`
+
+For each rule:
+
+1. `off` => skip
+2. `stoppedUntilUserInput` => skip
+3. `reminderCountInUserCycle >= maxRemindersPerUserCycle` => skip
+4. `on` => queue follow-up
+5. `auto` => queue follow-up only if rule's auto condition fails
+
+After queuing for a rule:
+
+- increment `reminderCountInUserCycle`
+
+## Commands (proposed)
+
+- `/rule-mode <rule-id> off|auto|on`
+- `/rule-status [rule-id]`
+- `/rule-stop <rule-id>` (sets stopped until next user input)
+- `/rule-set default-mode <rule-id> <off|auto|on>`
+- `/rule-set max-reminders <rule-id> <n>`
+- `/rule-config` (open interactive TUI editor for current session)
+
+Compatibility aliases can be added later:
+
+- `/ava-mode` -> `/rule-mode ava-end-prompt ...`
+- `/ava-status` -> filtered `/rule-status ava-end-prompt`
+
+## Tool API (proposed)
+
+### Generic done tool
+
+`session_rule_done`
+
+Parameters:
+
+```json
+{
+  "rule_id": "string"
+}
+```
+
+Effect:
+
+- sets `stoppedUntilUserInput = true` for that rule
+
+Optional per-rule no-arg aliases can be generated, but generic `rule_id` scales better.
+
+## Config files
+
+Proposed lookup:
+
+1. `.pi/extensions/session-followup-rules/config.json` (project)
+2. `~/.pi/agent/extensions/session-followup-rules/config.json` (global fallback)
+
+If both exist, project config overrides/extends global by `rule.id`.
+
+## Interactive TUI direction
+
+Use `ctx.ui.custom()` to provide a lightweight rule list/settings UI:
+
+- left pane: rules
+- right pane: mode + stopped state + preview of follow-up message + match strategy
+- quick actions: toggle mode, mark stopped, reset state
+
+Start with command-only configuration first; add TUI once core engine is stable.
+
+## Migration path from AVA extension
+
+1. Keep `agent-voice-adapter-reminder` unchanged now.
+2. Implement `session-followup-rules` with one default AVA rule.
+3. Verify equivalent behavior.
+4. Optionally deprecate AVA-specific extension later or keep it as thin preset wrapper.

--- a/session-followup-rules/PLAN.md
+++ b/session-followup-rules/PLAN.md
@@ -1,0 +1,45 @@
+# session-followup-rules: Implementation Plan
+
+## Phase 1: Rule engine skeleton
+
+- [ ] Create extension scaffold (`index.ts`, `package.json`, `README.md`)
+- [ ] Define TypeScript types for rules and runtime state
+- [ ] Implement config loading + validation with safe defaults
+- [ ] Add unit tests for matcher logic and auto-condition evaluation
+
+## Phase 2: Event wiring
+
+- [ ] Wire `input`, `agent_start`, `tool_call`, `tool_execution_end`, `agent_end`
+- [ ] Track matched tool calls by `toolCallId`
+- [ ] Support `mode` + `stoppedUntilUserInput` semantics per rule
+- [ ] Add per-rule reminder counters with `maxRemindersPerUserCycle`
+- [ ] Reset counters on real user input (`source !== "extension"`)
+- [ ] Queue follow-up with `sendUserMessage(..., { deliverAs: "followUp" })`
+
+## Phase 3: Control surface
+
+- [ ] Add `/rule-mode <rule-id> off|auto|on`
+- [ ] Add `/rule-status [rule-id]`
+- [ ] Add `/rule-stop <rule-id>`
+- [ ] Add `/rule-set default-mode <rule-id> <off|auto|on>`
+- [ ] Add `/rule-set max-reminders <rule-id> <n>`
+- [ ] Add `session_rule_done` tool (`rule_id` required)
+
+## Phase 4: AVA compatibility preset
+
+- [ ] Ship a default `ava-end-prompt` rule that mirrors current AVA behavior
+- [ ] Add optional compatibility aliases (`/ava-mode`, `/ava-status`)
+- [ ] Document differences from `agent-voice-adapter-reminder`
+
+## Phase 5: TUI configurator (optional)
+
+- [ ] Add `/rule-config` with `ctx.ui.custom()`
+- [ ] Rule picker + mode toggle + mark-stopped action
+- [ ] Persist per-session overrides cleanly
+
+## Open decisions
+
+1. Should follow-up delivery mode be configurable per rule (`followUp` vs `steer`)?
+2. Should rules support message-content matching in v1 or v2?
+3. Should per-session overrides persist via `appendEntry` or remain in-memory only?
+4. Should we expose one generic tool only, or generate per-rule no-arg tools?

--- a/session-followup-rules/README.md
+++ b/session-followup-rules/README.md
@@ -1,0 +1,24 @@
+# session-followup-rules
+
+Design-stage extension for generalized end-of-run follow-up behavior in pi.
+
+## Status
+
+This directory currently contains design notes and an implementation plan only.
+No extension code is wired yet.
+
+## Why this exists
+
+`agent-voice-adapter-reminder` solved one workflow (voice handoff), but the core
+pattern is reusable:
+
+- Observe runtime events (`input`, `tool_call`, `tool_execution_end`, `agent_end`)
+- Track per-session rule state (`off|auto|on`, stopped-until-user-input)
+- At `agent_end`, conditionally enqueue a follow-up user message
+
+`session-followup-rules` will generalize that behavior into configurable rules.
+
+## Design docs
+
+- [DESIGN.md](./DESIGN.md)
+- [PLAN.md](./PLAN.md)


### PR DESCRIPTION
## Summary

Adds a new `agent-voice-adapter-reminder` extension for voice-first pi workflows using `kcosr/agent-voice-adapter`.

### Included functionality

- New extension: `agent-voice-adapter-reminder/`
  - Session-scoped mode control via `/ava-mode off|auto|on`
  - Persisted defaults via `/ava-set default-mode <off|auto|on>` and `/ava-set max-reminders <n>`
  - Status command `/ava-status`
  - Manual stop command `/ava-reminder mark-stopped`
  - LLM-callable tool `agent_voice_adapter_session_done` (no args)
  - Auto follow-up at `agent_end` with suppression and per-session max reminder counting
  - Reminder count resets on real user input (`source !== "extension"`)
  - Tightened command matcher to `agent-voice-adapter-cli.js` only

- Repo docs updates
  - Add extension entry to root `README.md`
  - Add changelog entry under `Unreleased`

- New design docs for the planned generalized successor extension
  - `session-followup-rules/README.md`
  - `session-followup-rules/DESIGN.md`
  - `session-followup-rules/PLAN.md`

## Validation

- Ran tests:
  - `cd agent-voice-adapter-reminder && npm test`
