### PR TITLE
Refine AVA setting scopes and expand README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Added
 
 ### Changed
+- **agent-voice-adapter-reminder**: Make `/ava-set` session-scoped and add `/ava-set-default` for global defaults
+- **agent-voice-adapter-reminder**: Add `end-message-enabled` and `end-message` settings with no-wait end-message execution on `agent_end` when reminders are not sent
+- **agent-voice-adapter-reminder**: Expand README with feature summary, explicit persistence behavior, and a future enhancements section
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **agent-voice-adapter-reminder**: Make `/ava-set` session-scoped and add `/ava-set-default` for global defaults
 - **agent-voice-adapter-reminder**: Add `end-message-enabled` and `end-message` settings with no-wait end-message execution on `agent_end` when reminders are not sent
 - **agent-voice-adapter-reminder**: Expand README with feature summary, explicit persistence behavior, and a future enhancements section
+- **skill-picker**: Switch default skill scan directory to `~/.agents/skills` and add configurable `skillDirs` via `~/.pi/agent/extensions/skill-picker/config.json`
 
 ### Fixed
 

--- a/agent-voice-adapter-reminder/README.md
+++ b/agent-voice-adapter-reminder/README.md
@@ -6,39 +6,77 @@ Keep pi voice-first by nudging the agent to end with an interactive
 This extension is designed for workflows using
 [`kcosr/agent-voice-adapter`](https://github.com/kcosr/agent-voice-adapter).
 
-## What it does
+## Feature summary
 
-- Adds mode control via:
+- Adds mode and settings control via:
   - `/ava-mode off|auto|on` (per-session)
-  - `/ava-set default-mode <off|auto|on>`
-  - `/ava-set max-reminders <n>`
+  - `/ava-set <key> <value>` (per-session)
+  - `/ava-set-default <key> <value>` (global defaults for new sessions)
   - `/ava-status`
   - `/ava-reminder mark-stopped`
 - Adds an LLM-callable tool:
   - `agent_voice_adapter_session_done`
-- On `agent_end`, conditionally sends a follow-up instruction to use
-  `agent-voice-adapter-cli.js` in interactive mode.
+- On `agent_end`, either:
+  - sends a reminder prompt (if reminder conditions match), or
+  - sends a one-shot end message via `agent-voice-adapter-cli.js --no-wait` when reminders are not sent and end-message is enabled.
+
+## Keys for `/ava-set` and `/ava-set-default`
+
+- `mode` -> `off|auto|on`
+- `max-reminders` -> non-negative integer
+- `end-message-enabled` -> `true|false` (also accepts `on/off`, `yes/no`, `1/0`)
+- `end-message` -> text
+
+Examples:
+
+```text
+/ava-set max-reminders 3
+/ava-set end-message-enabled true
+/ava-set end-message Agent finished
+
+/ava-set-default mode auto
+/ava-set-default max-reminders 2
+/ava-set-default end-message-enabled false
+/ava-set-default end-message Agent finished
+```
 
 ## Mode behavior
 
-- `off`: never auto-nudge.
-- `auto` (default): nudge unless the **last successful tool call** in the run was
-  interactive `agent-voice-adapter-cli(.js)` (without `--no-wait`).
-- `on`: nudge at `agent_end` while under the session's max reminder count (unless marked stopped).
+- `off`: never auto-remind.
+- `auto` (default): remind unless the **last successful tool call** in the run was
+  interactive `agent-voice-adapter-cli.js` (without `--no-wait`).
+- `on`: remind at `agent_end` while under the session's max reminder count (unless marked stopped).
 
-`mark-stopped` and `agent_voice_adapter_session_done` suppress nudges until the next
+`mark-stopped` and `agent_voice_adapter_session_done` suppress reminders until the next
 real user input (`input.source !== "extension"`).
 
 Each session tracks reminder attempts and enforces a max count. The reminder counter
 resets on the next real user input.
 
-## Session scope and defaults
+## Defaults
 
-- `/ava-mode` is scoped to the active session.
-- `/ava-set default-mode ...` sets the mode default used when a session is first seen by the extension.
-- `/ava-set max-reminders ...` sets the default max reminders for new sessions.
-- Defaults are saved to:
-  - `~/.pi/agent/extensions/agent-voice-adapter-reminder/config.json`
+Global defaults are saved to:
+
+- `~/.pi/agent/extensions/agent-voice-adapter-reminder/config.json`
+
+Default values:
+
+- `defaultMode`: `auto`
+- `defaultMaxReminders`: `2`
+- `defaultEndMessageEnabled`: `false`
+- `defaultEndMessage`: `"Agent finished"`
+
+## Persistence behavior
+
+- Global defaults (`/ava-set-default ...`) are persisted to disk in `config.json`.
+- Session values (`/ava-set ...`, `/ava-mode ...`, reminder counters, stopped flag) are in-memory for the active runtime.
+- Session values are not currently restored after a pi restart.
+
+## Future enhancements
+
+- Persist session-scoped settings/state via session custom entries (`appendEntry`) so they survive restarts.
+- Add a small TUI settings panel for live rule/session editing without command memorization.
+- Expand from AVA-specific behavior to a generic `session-followup-rules` engine with configurable match rules.
 
 ## Installation
 
@@ -52,7 +90,7 @@ cp -R /path/to/pi-extensions/agent-voice-adapter-reminder ~/.pi/agent/extensions
 
 ## How command detection works
 
-Yes — because the voice interaction is invoked through the `bash` tool, the extension
+Because the voice interaction is invoked through the `bash` tool, the extension
 inspects bash tool calls and checks whether the command contains
 `agent-voice-adapter-cli.js` and does **not** include `--no-wait`.
 

--- a/agent-voice-adapter-reminder/index.ts
+++ b/agent-voice-adapter-reminder/index.ts
@@ -11,6 +11,8 @@ type AvaMode = "off" | "auto" | "on";
 interface AvaConfig {
 	defaultMode?: AvaMode;
 	defaultMaxReminders?: number;
+	defaultEndMessageEnabled?: boolean;
+	defaultEndMessage?: string;
 }
 
 interface SessionState {
@@ -20,10 +22,14 @@ interface SessionState {
 	interactiveVoiceToolCalls: Set<string>;
 	reminderCount: number;
 	maxReminders: number;
+	endMessageEnabled: boolean;
+	endMessage: string;
 }
 
 const AVA_FOLLOW_UP_PROMPT =
 	"Before you finish, prompt the user with agent-voice-adapter-cli.js in interactive mode (without --no-wait).";
+
+const DEFAULT_END_MESSAGE = "Agent finished";
 
 const CONFIG_PATH = path.join(
 	os.homedir(),
@@ -41,6 +47,24 @@ function parseNonNegativeInt(value: string): number | null {
 	return parsed;
 }
 
+function parseBoolean(value: string): boolean | null {
+	const normalized = value.trim().toLowerCase();
+	if (["true", "1", "yes", "on", "enabled"].includes(normalized)) return true;
+	if (["false", "0", "no", "off", "disabled"].includes(normalized)) return false;
+	return null;
+}
+
+function parseKeyValueArgs(args: string): { key: string; value: string } | null {
+	const trimmed = args.trim();
+	if (!trimmed) return null;
+	const splitAt = trimmed.indexOf(" ");
+	if (splitAt === -1) return { key: trimmed.toLowerCase(), value: "" };
+	return {
+		key: trimmed.slice(0, splitAt).toLowerCase(),
+		value: trimmed.slice(splitAt + 1).trim(),
+	};
+}
+
 function loadConfig(): AvaConfig {
 	try {
 		if (!fs.existsSync(CONFIG_PATH)) return {};
@@ -52,6 +76,12 @@ function loadConfig(): AvaConfig {
 		}
 		if (typeof parsed.defaultMaxReminders === "number" && parsed.defaultMaxReminders >= 0) {
 			config.defaultMaxReminders = Math.floor(parsed.defaultMaxReminders);
+		}
+		if (typeof parsed.defaultEndMessageEnabled === "boolean") {
+			config.defaultEndMessageEnabled = parsed.defaultEndMessageEnabled;
+		}
+		if (typeof parsed.defaultEndMessage === "string" && parsed.defaultEndMessage.trim().length > 0) {
+			config.defaultEndMessage = parsed.defaultEndMessage;
 		}
 		return config;
 	} catch {
@@ -80,6 +110,8 @@ export default function (pi: ExtensionAPI) {
 	const config = loadConfig();
 	let defaultMode: AvaMode = config.defaultMode ?? "auto";
 	let defaultMaxReminders = config.defaultMaxReminders ?? 2;
+	let defaultEndMessageEnabled = config.defaultEndMessageEnabled ?? false;
+	let defaultEndMessage = config.defaultEndMessage ?? DEFAULT_END_MESSAGE;
 
 	const sessionStates = new Map<string, SessionState>();
 
@@ -94,11 +126,21 @@ export default function (pi: ExtensionAPI) {
 				interactiveVoiceToolCalls: new Set<string>(),
 				reminderCount: 0,
 				maxReminders: defaultMaxReminders,
+				endMessageEnabled: defaultEndMessageEnabled,
+				endMessage: defaultEndMessage,
 			};
 			sessionStates.set(key, state);
 		}
 		return state;
 	};
+
+	const persistDefaults = (): { success: true } | { success: false; error: string } =>
+		saveConfig({
+			defaultMode,
+			defaultMaxReminders,
+			defaultEndMessageEnabled,
+			defaultEndMessage,
+		});
 
 	pi.on("input", async (event, ctx) => {
 		if (event.source !== "extension") {
@@ -139,10 +181,21 @@ export default function (pi: ExtensionAPI) {
 			reminderCount: state.reminderCount,
 			maxReminders: state.maxReminders,
 		});
-		if (!shouldQueue) return;
+		if (shouldQueue) {
+			state.reminderCount += 1;
+			pi.sendUserMessage(AVA_FOLLOW_UP_PROMPT);
+			return;
+		}
 
-		state.reminderCount += 1;
-		pi.sendUserMessage(AVA_FOLLOW_UP_PROMPT);
+		if (!state.endMessageEnabled) return;
+		try {
+			await pi.exec("agent-voice-adapter-cli.js", ["--no-wait", state.endMessage]);
+		} catch (error) {
+			if (ctx.hasUI) {
+				const message = error instanceof Error ? error.message : String(error);
+				ctx.ui.notify(`AVA end-message failed: ${message}`, "warning");
+			}
+		}
 	});
 
 	pi.registerCommand("ava-mode", {
@@ -166,53 +219,142 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("ava-set", {
-		description: "Set default config: /ava-set default-mode <off|auto|on> or /ava-set max-reminders <n>",
+		description: "Set session config: max-reminders | end-message-enabled | end-message | mode",
 		handler: async (args, ctx) => {
-			const parts = (args ?? "").trim().split(/\s+/).filter(Boolean);
-			if (parts.length !== 2) {
-				ctx.ui.notify("Usage: /ava-set default-mode <off|auto|on> OR /ava-set max-reminders <n>", "warning");
-				return;
-			}
-
-			const [key, value] = parts;
-			if (key === "default-mode") {
-				if (!isAvaMode(value)) {
-					ctx.ui.notify("Usage: /ava-set default-mode <off|auto|on>", "warning");
-					return;
-				}
-				defaultMode = value as AvaMode;
-				const result = saveConfig({ defaultMode, defaultMaxReminders });
-				if (!result.success) {
-					ctx.ui.notify(`Failed to save config: ${result.error}`, "error");
-					return;
-				}
+			const state = getSessionState(ctx);
+			const parsed = parseKeyValueArgs(args ?? "");
+			if (!parsed || !parsed.key) {
 				ctx.ui.notify(
-					`ava-set saved default-mode=${defaultMode} (applies to new sessions)`,
-					"info",
+					"Usage: /ava-set <max-reminders|end-message-enabled|end-message|mode> <value>",
+					"warning",
 				);
 				return;
 			}
 
+			const { key, value } = parsed;
+
 			if (key === "max-reminders") {
-				const parsed = parseNonNegativeInt(value);
-				if (parsed === null) {
+				const n = parseNonNegativeInt(value);
+				if (n === null) {
 					ctx.ui.notify("Usage: /ava-set max-reminders <non-negative integer>", "warning");
 					return;
 				}
-				defaultMaxReminders = parsed;
-				const result = saveConfig({ defaultMode, defaultMaxReminders });
-				if (!result.success) {
-					ctx.ui.notify(`Failed to save config: ${result.error}`, "error");
+				state.maxReminders = n;
+				ctx.ui.notify(`ava-set max-reminders=${state.maxReminders} (session)`, "info");
+				return;
+			}
+
+			if (key === "end-message-enabled") {
+				const enabled = parseBoolean(value);
+				if (enabled === null) {
+					ctx.ui.notify("Usage: /ava-set end-message-enabled <true|false>", "warning");
 					return;
 				}
+				state.endMessageEnabled = enabled;
+				ctx.ui.notify(`ava-set end-message-enabled=${state.endMessageEnabled} (session)`, "info");
+				return;
+			}
+
+			if (key === "end-message") {
+				if (!value) {
+					ctx.ui.notify("Usage: /ava-set end-message <text>", "warning");
+					return;
+				}
+				state.endMessage = value;
+				ctx.ui.notify(`ava-set end-message=\"${state.endMessage}\" (session)`, "info");
+				return;
+			}
+
+			if (key === "mode") {
+				if (!isAvaMode(value)) {
+					ctx.ui.notify("Usage: /ava-set mode <off|auto|on>", "warning");
+					return;
+				}
+				state.mode = value as AvaMode;
+				ctx.ui.notify(`ava-set mode=${state.mode} (session)`, "info");
+				return;
+			}
+
+			ctx.ui.notify("Unknown key. Valid keys: max-reminders, end-message-enabled, end-message, mode", "warning");
+		},
+	});
+
+	pi.registerCommand("ava-set-default", {
+		description: "Set global defaults for new sessions: max-reminders | end-message-enabled | end-message | mode",
+		handler: async (args, ctx) => {
+			const parsed = parseKeyValueArgs(args ?? "");
+			if (!parsed || !parsed.key) {
 				ctx.ui.notify(
-					`ava-set saved max-reminders=${defaultMaxReminders} (applies to new sessions)`,
-					"info",
+					"Usage: /ava-set-default <max-reminders|end-message-enabled|end-message|mode> <value>",
+					"warning",
 				);
 				return;
 			}
 
-			ctx.ui.notify("Unknown key. Valid keys: default-mode, max-reminders", "warning");
+			const { key, value } = parsed;
+			if (key === "max-reminders") {
+				const n = parseNonNegativeInt(value);
+				if (n === null) {
+					ctx.ui.notify("Usage: /ava-set-default max-reminders <non-negative integer>", "warning");
+					return;
+				}
+				defaultMaxReminders = n;
+				const result = persistDefaults();
+				if (!result.success) {
+					ctx.ui.notify(`Failed to save config: ${result.error}`, "error");
+					return;
+				}
+				ctx.ui.notify(`ava-set-default max-reminders=${defaultMaxReminders}`, "info");
+				return;
+			}
+
+			if (key === "end-message-enabled") {
+				const enabled = parseBoolean(value);
+				if (enabled === null) {
+					ctx.ui.notify("Usage: /ava-set-default end-message-enabled <true|false>", "warning");
+					return;
+				}
+				defaultEndMessageEnabled = enabled;
+				const result = persistDefaults();
+				if (!result.success) {
+					ctx.ui.notify(`Failed to save config: ${result.error}`, "error");
+					return;
+				}
+				ctx.ui.notify(`ava-set-default end-message-enabled=${defaultEndMessageEnabled}`, "info");
+				return;
+			}
+
+			if (key === "end-message") {
+				if (!value) {
+					ctx.ui.notify("Usage: /ava-set-default end-message <text>", "warning");
+					return;
+				}
+				defaultEndMessage = value;
+				const result = persistDefaults();
+				if (!result.success) {
+					ctx.ui.notify(`Failed to save config: ${result.error}`, "error");
+					return;
+				}
+				ctx.ui.notify(`ava-set-default end-message=\"${defaultEndMessage}\"`, "info");
+				return;
+			}
+
+			if (key === "mode") {
+				if (!isAvaMode(value)) {
+					ctx.ui.notify("Usage: /ava-set-default mode <off|auto|on>", "warning");
+					return;
+				}
+				defaultMode = value as AvaMode;
+				const result = persistDefaults();
+				if (!result.success) {
+					ctx.ui.notify(`Failed to save config: ${result.error}`, "error");
+					return;
+				}
+				ctx.ui.notify(`ava-set-default mode=${defaultMode}`, "info");
+				return;
+			}
+
+			ctx.ui.notify("Unknown key. Valid keys: max-reminders, end-message-enabled, end-message, mode", "warning");
 		},
 	});
 
@@ -221,7 +363,7 @@ export default function (pi: ExtensionAPI) {
 		handler: async (_args, ctx) => {
 			const state = getSessionState(ctx);
 			ctx.ui.notify(
-				`ava-status mode=${state.mode}, defaultMode=${defaultMode}, reminderCount=${state.reminderCount}/${state.maxReminders}, defaultMaxReminders=${defaultMaxReminders}, stoppedUntilUserInput=${state.stoppedUntilUserInput}, lastSuccessfulToolWasInteractiveVoice=${state.lastSuccessfulToolWasInteractiveVoice}`,
+				`ava-status mode=${state.mode}, defaultMode=${defaultMode}, reminderCount=${state.reminderCount}/${state.maxReminders}, defaultMaxReminders=${defaultMaxReminders}, endMessageEnabled=${state.endMessageEnabled}, defaultEndMessageEnabled=${defaultEndMessageEnabled}, endMessage=\"${state.endMessage}\", defaultEndMessage=\"${defaultEndMessage}\", stoppedUntilUserInput=${state.stoppedUntilUserInput}, lastSuccessfulToolWasInteractiveVoice=${state.lastSuccessfulToolWasInteractiveVoice}`,
 				"info",
 			);
 		},
@@ -260,6 +402,10 @@ export default function (pi: ExtensionAPI) {
 					reminderCount: state.reminderCount,
 					maxReminders: state.maxReminders,
 					defaultMaxReminders,
+					endMessageEnabled: state.endMessageEnabled,
+					defaultEndMessageEnabled,
+					endMessage: state.endMessage,
+					defaultEndMessage,
 					stoppedUntilUserInput: state.stoppedUntilUserInput,
 					lastSuccessfulToolWasInteractiveVoice: state.lastSuccessfulToolWasInteractiveVoice,
 				},

--- a/agent-voice-adapter-reminder/index.ts
+++ b/agent-voice-adapter-reminder/index.ts
@@ -190,6 +190,9 @@ export default function (pi: ExtensionAPI) {
 		if (!state.endMessageEnabled) return;
 		try {
 			await pi.exec("agent-voice-adapter-cli.js", ["--no-wait", state.endMessage]);
+			if (ctx.hasUI) {
+				ctx.ui.notify(`agent-voice-adapter end message sent: "${state.endMessage}"`, "info");
+			}
 		} catch (error) {
 			if (ctx.hasUI) {
 				const message = error instanceof Error ? error.message : String(error);

--- a/skill-picker/README.md
+++ b/skill-picker/README.md
@@ -46,14 +46,26 @@ Queued skills are applied to your next message.
 
 ## Skill Locations
 
-Skills are loaded from these directories (in order):
+By default, skills are loaded from:
 
-1. `~/.codex/skills/` — Codex user skills (recursive)
-2. `~/.claude/skills/` — Claude user skills (one level deep)
-3. `.claude/skills/` — Claude project skills (one level deep)
-4. `~/.pi/agent/skills/` — Pi user skills (recursive)
-5. `~/.pi/skills/` — Legacy user skills (recursive)
-6. `.pi/skills/` — Pi project skills (recursive)
+1. `~/.agents/skills/` — recursive scan for `SKILL.md`
+
+You can override scan directories via:
+
+`~/.pi/agent/extensions/skill-picker/config.json`
+
+```json
+{
+  "skillDirs": [
+    { "dir": "~/.agents/skills", "format": "recursive" }
+  ]
+}
+```
+
+- `dir`: absolute path or `~/...` path
+- `format`:
+  - `recursive` (search all subdirectories for `SKILL.md`)
+  - `claude` (one level deep; each direct child directory must contain `SKILL.md`)
 
 Each skill must live in its own directory with a `SKILL.md` that includes frontmatter:
 

--- a/skill-picker/index.ts
+++ b/skill-picker/index.ts
@@ -115,6 +115,66 @@ interface SkillDirConfig {
 	format: SkillFormat;
 }
 
+interface SkillPickerConfig {
+	skillDirs?: Array<SkillDirConfig | string>;
+}
+
+const SKILL_PICKER_CONFIG_PATH = path.join(
+	os.homedir(),
+	".pi",
+	"agent",
+	"extensions",
+	"skill-picker",
+	"config.json",
+);
+
+const DEFAULT_SKILL_DIRS: SkillDirConfig[] = [
+	{ dir: path.join(os.homedir(), ".agents", "skills"), format: "recursive" },
+];
+
+function expandHomePath(inputPath: string): string {
+	if (inputPath === "~") return os.homedir();
+	if (inputPath.startsWith("~/")) {
+		return path.join(os.homedir(), inputPath.slice(2));
+	}
+	return inputPath;
+}
+
+function normalizeSkillDirConfig(entry: SkillDirConfig | string): SkillDirConfig | null {
+	if (typeof entry === "string") {
+		const dir = expandHomePath(entry.trim());
+		if (!dir) return null;
+		return { dir, format: "recursive" };
+	}
+
+	if (!entry || typeof entry !== "object") return null;
+	const dir = typeof entry.dir === "string" ? expandHomePath(entry.dir.trim()) : "";
+	if (!dir) return null;
+	const format: SkillFormat = entry.format === "claude" ? "claude" : "recursive";
+	return { dir, format };
+}
+
+function loadSkillDirs(): SkillDirConfig[] {
+	try {
+		if (!fs.existsSync(SKILL_PICKER_CONFIG_PATH)) {
+			return DEFAULT_SKILL_DIRS;
+		}
+		const content = fs.readFileSync(SKILL_PICKER_CONFIG_PATH, "utf-8");
+		const config = JSON.parse(content) as SkillPickerConfig;
+		if (!Array.isArray(config.skillDirs)) {
+			return DEFAULT_SKILL_DIRS;
+		}
+
+		const normalized = config.skillDirs
+			.map((entry) => normalizeSkillDirConfig(entry))
+			.filter((entry): entry is SkillDirConfig => entry !== null);
+
+		return normalized.length > 0 ? normalized : DEFAULT_SKILL_DIRS;
+	} catch {
+		return DEFAULT_SKILL_DIRS;
+	}
+}
+
 /**
  * Scan a directory for skills based on the format
  * - "recursive": scans directories recursively looking for SKILL.md files
@@ -206,25 +266,13 @@ function loadSkillFromFile(filePath: string, skillsByName: Map<string, Skill>): 
 }
 
 /**
- * Load skills from known directories
- * Matches pi's skill loading order:
- * 1. ~/.codex/skills (recursive)
- * 2. ~/.claude/skills (claude format - one level)
- * 3. ${cwd}/.claude/skills (claude format - one level)
- * 4. ~/.pi/agent/skills (recursive)
- * 5. ${cwd}/.pi/skills (recursive)
+ * Load skills from configured directories.
+ *
+ * Defaults to ~/.agents/skills when no config file is present.
  */
 function loadSkills(): Skill[] {
 	const skillsByName = new Map<string, Skill>();
-	
-	const skillDirs: SkillDirConfig[] = [
-		{ dir: path.join(os.homedir(), ".codex", "skills"), format: "recursive" },
-		{ dir: path.join(os.homedir(), ".claude", "skills"), format: "claude" },
-		{ dir: path.join(process.cwd(), ".claude", "skills"), format: "claude" },
-		{ dir: path.join(os.homedir(), ".pi", "agent", "skills"), format: "recursive" },
-		{ dir: path.join(os.homedir(), ".pi", "skills"), format: "recursive" },
-		{ dir: path.join(process.cwd(), ".pi", "skills"), format: "recursive" },
-	];
+	const skillDirs = loadSkillDirs();
 
 	for (const { dir, format } of skillDirs) {
 		scanSkillDir(dir, format, skillsByName);


### PR DESCRIPTION
## Summary

Refines `agent-voice-adapter-reminder` settings behavior and updates documentation.

### Functional updates

- Make `/ava-set` session-scoped for per-session overrides.
- Add `/ava-set-default` for persisted global defaults (applies to new sessions).
- Add end-message settings:
  - `end-message-enabled` (default: `false`)
  - `end-message` (default: `"Agent finished"`)
- On `agent_end`, execute `agent-voice-adapter-cli.js --no-wait <end-message>` only when no reminder is sent and end-message is enabled.

### Documentation updates

- Expand extension README with:
  - feature summary
  - settings keys and examples
  - persistence behavior (what is persisted vs runtime-only)
  - future enhancements section
- Update `CHANGELOG.md` under `Unreleased`.

## Validation

- `cd agent-voice-adapter-reminder && npm test`
