### PR TITLE
Polish apply_patch prompt and result rendering

### DIFF
--- a/apply-patch-tool/apply_patch_prompt.md
+++ b/apply-patch-tool/apply_patch_prompt.md
@@ -1,7 +1,9 @@
 ## `apply_patch`
 
-Use the `apply_patch` shell command to edit files.
-Your patch language is a stripped‑down, file‑oriented diff format designed to be easy to parse and safe to apply. You can think of it as a high‑level envelope:
+Use the `apply_patch` tool to create, edit, rename, and delete files.
+Pass the whole patch as the tool's `input` string. Do not call `apply_patch` through `bash` or a shell command.
+
+The patch language is a stripped-down, file-oriented diff format designed to be easy to parse and safe to apply. You can think of it as a high-level envelope:
 
 *** Begin Patch
 [ one or more file sections ]
@@ -16,10 +18,14 @@ Each operation starts with one of three headers:
 *** Update File: <path> - patch an existing file in place (optionally with a rename).
 
 May be immediately followed by *** Move to: <new path> if you want to rename the file.
-Then one or more “hunks”, each introduced by @@ (optionally followed by a hunk header).
+Then one or more hunks, each introduced by `@@` optionally followed by a hunk header.
 Within a hunk each line starts with:
 
-For instructions on [context_before] and [context_after]:
+- space (` `) for unchanged context
+- `-` for lines to remove
+- `+` for lines to add
+
+For editing existing files:
 - By default, show 3 lines of code immediately above and 3 lines immediately below each change. If a change is within 3 lines of a previous change, do NOT duplicate the first change’s [context_after] lines in the second change’s [context_before] lines.
 - If 3 lines of context is insufficient to uniquely identify the snippet of code within the file, use the @@ operator to indicate the class or function to which the snippet belongs. For instance, we might have:
 @@ class BaseClass
@@ -49,6 +55,42 @@ MoveTo := "*** Move to: " newPath NEWLINE
 Hunk := "@@" [ header ] NEWLINE { HunkLine } [ "*** End of File" NEWLINE ]
 HunkLine := (" " | "-" | "+") text NEWLINE
 
+Create a new file:
+
+*** Begin Patch
+*** Add File: src/hello.txt
++export function hello() {
++  return "Hello, world!";
++}
+*** End Patch
+
+Edit an existing file:
+
+*** Begin Patch
+*** Update File: src/app.ts
+@@
+ function greet() {
+-  return "Hi";
++  return "Hello, world!";
+ }
+*** End Patch
+
+Rename and edit a file:
+
+*** Begin Patch
+*** Update File: src/app.py
+*** Move to: src/main.py
+@@ def greet():
+-print("Hi")
++print("Hello, world!")
+*** End Patch
+
+Delete a file:
+
+*** Begin Patch
+*** Delete File: obsolete.txt
+*** End Patch
+
 A full patch can combine several operations:
 
 *** Begin Patch
@@ -64,12 +106,10 @@ A full patch can combine several operations:
 
 It is important to remember:
 
-- You must include a header with your intended action (Add/Delete/Update)
-- You must prefix new lines with `+` even when creating a new file
-- File references can only be relative, NEVER ABSOLUTE.
+- You must include a header with your intended action (Add/Delete/Update).
+- For `*** Add File`, every content line must start with `+`.
+- For `*** Update File`, include enough unchanged context lines (space-prefixed) to uniquely identify the edit.
+- File references can only be relative, NEVER absolute.
+- Prefer `apply_patch` for normal file edits. Use other tools only when generated output or bulk scripted changes are more appropriate.
 
-You can invoke apply_patch like:
-
-```
-shell {"command":["apply_patch","*** Begin Patch\n*** Add File: hello.txt\n+Hello, world!\n*** End Patch\n"]}
-```
+Invoke it as a tool call with an `input` field containing the patch text.

--- a/apply-patch-tool/index.ts
+++ b/apply-patch-tool/index.ts
@@ -8,6 +8,7 @@ import { buildToolOutput } from "./tool-output.js";
 
 const PROMPT_MESSAGE_TYPE = "apply-patch-tool-instructions";
 const PROMPT_FILENAME = "apply_patch_prompt.md";
+const COLLAPSED_DIFF_LINES = 10;
 
 function getExtensionDir(): string {
   return path.dirname(fileURLToPath(import.meta.url));
@@ -22,6 +23,139 @@ function isCustomMessageEntry(entry: unknown): entry is { type: "custom_message"
   if (!entry || typeof entry !== "object") return false;
   const record = entry as Record<string, unknown>;
   return record.type === "custom_message" && typeof record.customType === "string";
+}
+
+function textContent(result: any): string {
+  const content = result?.content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => (part && part.type === "text" && typeof part.text === "string" ? part.text : ""))
+    .filter(Boolean)
+    .join("\n");
+}
+
+function style(theme: any, color: string, text: string): string {
+  if (theme && typeof theme.fg === "function") return theme.fg(color, text);
+  switch (color) {
+    case "toolDiffAdded":
+    case "success":
+      return `\x1b[32m${text}\x1b[39m`;
+    case "toolDiffRemoved":
+    case "error":
+      return `\x1b[31m${text}\x1b[39m`;
+    case "accent":
+      return `\x1b[36m${text}\x1b[39m`;
+    case "muted":
+    case "toolDiffContext":
+    case "toolOutput":
+      return `\x1b[90m${text}\x1b[39m`;
+    default:
+      return text;
+  }
+}
+
+function colorizeDiffLine(line: string, theme: any): string {
+  if (line.startsWith("+++") || line.startsWith("---")) return style(theme, "muted", line);
+  if (line.startsWith("+")) return style(theme, "toolDiffAdded", line);
+  if (line.startsWith("-")) return style(theme, "toolDiffRemoved", line);
+  if (line.startsWith("@@")) return style(theme, "accent", line);
+  if (line.startsWith("diff --git")) return style(theme, "muted", line);
+  return style(theme, "toolDiffContext", line);
+}
+
+function trimTrailingEmptyLines(lines: string[]): string[] {
+  let end = lines.length;
+  while (end > 0 && lines[end - 1] === "") end--;
+  return lines.slice(0, end);
+}
+
+function diffLines(result: any): string[] {
+  const files = Array.isArray(result?.details?.files) ? result.details.files : [];
+  const lines: string[] = [];
+
+  for (const file of files) {
+    if (typeof file?.unifiedDiff !== "string" || file.unifiedDiff.trim() === "") continue;
+    if (lines.length > 0) lines.push("");
+    lines.push(...file.unifiedDiff.split("\n"));
+  }
+
+  if (lines.length > 0) return trimTrailingEmptyLines(lines);
+
+  const rawLines = textContent(result).split("\n").filter((line) => line.trim() !== "");
+  for (const line of rawLines) {
+    if (line.startsWith("Applied patch")) continue;
+    lines.push(line);
+  }
+
+  return trimTrailingEmptyLines(lines);
+}
+
+class PlainTextComponent {
+  private value: string;
+
+  constructor(value = "") {
+    this.value = value;
+  }
+
+  setText(value: string) {
+    this.value = value;
+  }
+
+  render(width: number): string[] {
+    const safeWidth = Math.max(1, width || 80);
+    const lines: string[] = [];
+    for (const line of this.value.split("\n")) {
+      if (line.length <= safeWidth) {
+        lines.push(line);
+        continue;
+      }
+      for (let index = 0; index < line.length; index += safeWidth) {
+        lines.push(line.slice(index, index + safeWidth));
+      }
+    }
+    return lines.length > 0 ? lines : [""];
+  }
+
+  invalidate() {}
+}
+
+function resultText(result: any, expanded: boolean, theme: any): string {
+  const details = result?.details;
+  const files = Array.isArray(details?.files) ? details.files : [];
+  const added = Array.isArray(details?.added) ? details.added.length : 0;
+  const modified = Array.isArray(details?.modified) ? details.modified.length : 0;
+  const deleted = Array.isArray(details?.deleted) ? details.deleted.length : 0;
+
+  const total = files.length || added + modified + deleted;
+  const summary = total === 1 ? "1 file" : `${total} files`;
+  const counts = [`A ${added}`, `M ${modified}`, `D ${deleted}`].filter((part) => !part.endsWith(" 0"));
+
+  let text = `✓ Applied patch: ${summary}`;
+  if (counts.length > 0) text += ` (${counts.join(", ")})`;
+
+  const visibleFiles = files.slice(0, 6);
+  for (const file of visibleFiles) {
+    const status = file.status === "added" ? "A" : file.status === "deleted" ? "D" : "M";
+    const filePath = typeof file.path === "string" ? file.path : file.moveTo || file.moveFrom || "unknown";
+    const move = file.moveFrom && file.moveTo ? ` (${file.moveFrom} → ${file.moveTo})` : "";
+    text += `\n  ${status} ${filePath}${move}`;
+  }
+  if (files.length > visibleFiles.length) {
+    text += `\n  … ${files.length - visibleFiles.length} more`;
+  }
+
+  const lines = diffLines(result);
+  if (lines.length > 0) {
+    const maxLines = expanded ? lines.length : COLLAPSED_DIFF_LINES;
+    const displayLines = lines.slice(0, maxLines);
+    const remaining = lines.length - maxLines;
+    text += `\n\n${displayLines.map((line) => colorizeDiffLine(line, theme)).join("\n")}`;
+    if (remaining > 0) {
+      text += style(theme, "muted", `\n... (${remaining} more lines, ${lines.length} total, Ctrl+O to expand)`);
+    }
+  }
+
+  return text;
 }
 
 export default function (pi: ExtensionAPI) {
@@ -56,12 +190,21 @@ export default function (pi: ExtensionAPI) {
         description: "Patch text starting with *** Begin Patch and ending with *** End Patch.",
       }),
     }),
-    async execute(_toolCallId, params, _onUpdate, ctx) {
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const result = applyPatch(params.input, ctx.cwd);
       return {
         content: [{ type: "text", text: buildToolOutput(result) }],
         details: result.details,
       };
+    },
+    renderResult(result, { expanded, isPartial }, _theme, context) {
+      const text = (context.lastComponent as PlainTextComponent | undefined) ?? new PlainTextComponent();
+      if (isPartial) {
+        text.setText("Applying patch…");
+        return text;
+      }
+      text.setText(resultText(result, expanded, _theme));
+      return text;
     },
   });
 }


### PR DESCRIPTION
## Summary

Polishes the `apply_patch` tool UX:

- Fixes the tool `execute` signature so `ctx.cwd` is passed correctly.
- Updates the prompt instructions to describe `apply_patch` as a Pi tool call with an `input` field, not a shell command.
- Adds examples for creating, editing, renaming, and deleting files.
- Adds custom result rendering:
  - compact applied-file summary
  - changed file list
  - collapsed diff preview matching native `write` behavior
  - `Ctrl+O` expansion for full diffs
  - colored diff lines for additions/removals/context/hunks

## Testing

- `NODE_OPTIONS="--import /Users/safzan/.nvm/versions/node/v22.20.0/lib/node_modules/vercel/node_modules/tsx/dist/loader.mjs" node --test index.test.ts patch.test.ts`
- Manual render harness for collapsed and expanded colored diff output

## Preview

<img width="904" alt="apply_patch collapsed colored diff preview" src="https://raw.githubusercontent.com/safzanpirani/pi-extensions-1/pr-preview-assets/preview/apply-patch-preview.png" />
